### PR TITLE
refactor: FF-22 renamed/changed contract for ToggleConfiguration

### DIFF
--- a/ioet_feature_flag/__init__.py
+++ b/ioet_feature_flag/__init__.py
@@ -1,2 +1,2 @@
 from .feature_router import FeatureRouter, TogglePoint
-from .factories.adapters import get_toggle_configuration
+from .factories.toggle_configuration import get_toggle_configuration

--- a/ioet_feature_flag/_exceptions.py
+++ b/ioet_feature_flag/_exceptions.py
@@ -1,0 +1,4 @@
+class ToggleNotFoundError(Exception):
+    """
+    Exception raised when a toggle is not found or registered
+    """

--- a/ioet_feature_flag/factories/adapters.py
+++ b/ioet_feature_flag/factories/adapters.py
@@ -1,6 +1,0 @@
-from ..toggle_configuration.base import FeatureRepositoryAdapter
-from ..toggle_configuration.json_adapter import JSONAdapter
-
-
-def get_toggle_configuration() -> FeatureRepositoryAdapter:
-    return JSONAdapter(config_path="feaure_toggles.json")

--- a/ioet_feature_flag/factories/toggle_configuration.py
+++ b/ioet_feature_flag/factories/toggle_configuration.py
@@ -1,0 +1,6 @@
+from ..toggle_configuration.base import ToggleConfiguration
+from ..toggle_configuration.json_adapter import JSONAdapter
+
+
+def get_toggle_configuration() -> ToggleConfiguration:
+    return JSONAdapter(toggles_file_path="feaure_toggles.json")

--- a/ioet_feature_flag/feature_router.py
+++ b/ioet_feature_flag/feature_router.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from .factories.adapters import get_toggle_configuration
+from .factories.toggle_configuration import get_toggle_configuration
 
 
 class FeatureRouter:

--- a/ioet_feature_flag/toggle_configuration/base.py
+++ b/ioet_feature_flag/toggle_configuration/base.py
@@ -1,12 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Tuple, List
 
 
-class FeatureRepositoryAdapter(ABC):
+class ToggleConfiguration(ABC):
     @abstractmethod
-    def get_flags(self) -> Dict:
-        raise NotImplementedError
-
-    @abstractmethod
-    def set_flag(self, flag_name: str, is_flag_enabled: bool) -> Dict:
+    def get_toggles(self, toggle_names: List[str]) -> Tuple[bool, ...]:
         raise NotImplementedError

--- a/tests/unit/toggle_configuration/test_aws_appconfig_adapter.py
+++ b/tests/unit/toggle_configuration/test_aws_appconfig_adapter.py
@@ -1,9 +1,21 @@
 import appconfig_helper
 from unittest import mock
+import pytest
 
+from ioet_feature_flag.toggle_configuration.base import ToggleConfiguration
 from ioet_feature_flag.toggle_configuration.aws_appconfig_adapter import (
     AWSAppConfigAdapter,
 )
+from ioet_feature_flag._exceptions import ToggleNotFoundError
+
+
+@pytest.fixture(autouse=True)
+def _mock_aws_env_variables(monkeypatch):
+    monkeypatch.setenv("AWS_REGION", "test-region")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "test-region")
+    monkeypatch.setenv("AWS_APPCONFIG_APP", "test-app")
+    monkeypatch.setenv("AWS_APPCONFIG_ENV", "test-env")
+    monkeypatch.setenv("AWS_APPCONFIG_PROFILE", "test-profile")
 
 
 class TestAWSAppconfigAdapter:
@@ -11,60 +23,45 @@ class TestAWSAppconfigAdapter:
         "ioet_feature_flag.toggle_configuration.aws_appconfig_adapter.AppConfigHelper",
         autospec=True,
     )
-    def test_get_flags(self, appconfig_cls, monkeypatch):
-        monkeypatch.setenv("AWS_REGION", "test-region")
-        monkeypatch.setenv("AWS_DEFAULT_REGION", "test-region")
-        monkeypatch.setenv("AWS_APPCONFIG_APP", "test-app")
-        monkeypatch.setenv("AWS_APPCONFIG_ENV", "test-env")
-        monkeypatch.setenv("AWS_APPCONFIG_PROFILE", "test-profile")
-        expected_flags = {
-            "flag_1": {
-                "enabled": True,
-            },
-            "flag_2": {
-                "enabled": False,
-            },
+    def test__returns_the_toggles_specified_in_the_config(self, appconfig_cls):
+        toggles = {
+            "some_toggle": {"enabled": True},
+            "another_toggle": {"enabled": False},
         }
         mock_appconfig = mock.create_autospec(
             appconfig_helper.AppConfigHelper,
-            config=expected_flags,
+            config=toggles,
         )
         appconfig_cls.return_value = mock_appconfig
-        actual_flags = AWSAppConfigAdapter().get_flags()
 
-        assert expected_flags == actual_flags
+        toggle_provider: ToggleConfiguration = AWSAppConfigAdapter()
+        some_toggle, another_toggle = toggle_provider.get_toggles(
+            ["some_toggle", "another_toggle"]
+        )
+
+        assert some_toggle == toggles["some_toggle"]["enabled"]
+        assert another_toggle == toggles["another_toggle"]["enabled"]
 
     @mock.patch(
         "ioet_feature_flag.toggle_configuration.aws_appconfig_adapter.AppConfigHelper",
         autospec=True,
     )
-    def test_set_flag(self, appconfig_cls, monkeypatch):
-        monkeypatch.setenv("AWS_REGION", "test-region")
-        monkeypatch.setenv("AWS_DEFAULT_REGION", "test-region")
-        monkeypatch.setenv("AWS_APPCONFIG_APP", "test-app")
-        monkeypatch.setenv("AWS_APPCONFIG_ENV", "test-env")
-        monkeypatch.setenv("AWS_APPCONFIG_PROFILE", "test-profile")
-        outdated_flags = {
-            "flag_1": {
-                "enabled": True,
-            },
-            "flag_2": {
-                "enabled": False,
-            },
-        }
-        expected_flags = {
-            "flag_1": {
-                "enabled": False,
-            },
-            "flag_2": {
-                "enabled": False,
-            },
+    def test__raises_an_error__if_one_of_the_toggles_does_not_exist(
+        self, appconfig_cls
+    ):
+        toggles = {
+            "some_toggle": {"enabled": True},
         }
         mock_appconfig = mock.create_autospec(
             appconfig_helper.AppConfigHelper,
-            config=outdated_flags,
+            config=toggles,
         )
         appconfig_cls.return_value = mock_appconfig
-        actual_flags = AWSAppConfigAdapter().set_flag("flag_1", False)
+        toggle_provider: ToggleConfiguration = AWSAppConfigAdapter()
 
-        assert expected_flags == actual_flags
+        with pytest.raises(ToggleNotFoundError) as error:
+            toggle_provider.get_toggles(["some_toggle", "another_toggle"])
+
+        assert (
+            str(error.value) == "The follwing toggles where not found: another_toggle"
+        )

--- a/tests/unit/toggle_configuration/test_json_adapter.py
+++ b/tests/unit/toggle_configuration/test_json_adapter.py
@@ -1,69 +1,57 @@
-from unittest.mock import mock_open
+import os
+import typing
+import pytest
 import json
 
+from ioet_feature_flag.toggle_configuration.base import ToggleConfiguration
 from ioet_feature_flag.toggle_configuration.json_adapter import JSONAdapter
+from ioet_feature_flag._exceptions import ToggleNotFoundError
+
+
+_TOGGLES_FILE = "/tmp/app_toggles_test.json"
+
+
+@pytest.fixture(autouse=True)
+def _clear_toggles_file():
+    yield
+    if os.path.exists(_TOGGLES_FILE):
+        os.remove(_TOGGLES_FILE)
+
+
+@pytest.fixture(name="add_toggles")
+def _add_toggles():
+    def _add(toggles: typing.Dict[str, bool]) -> None:
+        with open(_TOGGLES_FILE, "w") as toggles_file:
+            json.dump(toggles, toggles_file)
+
+    return _add
 
 
 class TestJsonAdapter:
-    def test_get_flags_when_there_is_a_file_returns_flags_dictionry(
-        self, mocker, monkeypatch
+    def test__returns_the_toggles_specified_in_the_file(
+        self, add_toggles: typing.Callable[[typing.Dict[str, bool]], None]
     ):
-        path = "configuration.json"
-        expected_flags = {"flag_1": True, "flag_2": False}
-        json_load_mock = mocker.Mock(return_value=expected_flags)
-        mocker.patch(
-            "ioet_feature_flag.toggle_configuration.json_adapter.open",
-            new_callable=mock_open,
-        )
-        monkeypatch.setattr(json, "load", json_load_mock)
+        toggles = {"some_toggle": True, "another_toggle": False}
+        add_toggles(toggles)
 
-        actual_flags = JSONAdapter(path).get_flags()
-
-        assert expected_flags == actual_flags
-
-    def test_get_flags_when_there_is_no_file_returns_empty_dictionary(self, mocker):
-        path = "configuration.json"
-        mocker.patch(
-            "ioet_feature_flag.toggle_configuration.json_adapter.open",
-            side_effect=FileNotFoundError,
+        toggle_provider: ToggleConfiguration = JSONAdapter(_TOGGLES_FILE)
+        some_toggle, another_toggle = toggle_provider.get_toggles(
+            ["some_toggle", "another_toggle"]
         )
 
-        actual_flags = JSONAdapter(path).get_flags()
+        assert some_toggle == toggles["some_toggle"]
+        assert another_toggle == toggles["another_toggle"]
 
-        assert {} == actual_flags
-
-    def test_set_flag_when_file_exists_then_returns_updated_flags(
-        self, mocker, monkeypatch
+    def test__raises_an_error__if_one_of_the_toggles_does_not_exist(
+        self, add_toggles: typing.Callable[[typing.Dict[str, bool]], None]
     ):
-        path = "configuration.json"
-        outdated_flags = {"flag_1": True, "flag_2": False}
-        expected_flags = {"flag_1": False, "flag_2": False}
-        json_load_mock = mocker.Mock(return_value=outdated_flags)
-        json_dump_mock = mocker.Mock()
-        mocker.patch(
-            "ioet_feature_flag.toggle_configuration.json_adapter.open",
-            new_callable=mock_open,
+        toggles = {"some_toggle": True}
+        add_toggles(toggles)
+        toggle_provider: ToggleConfiguration = JSONAdapter(_TOGGLES_FILE)
+
+        with pytest.raises(ToggleNotFoundError) as error:
+            toggle_provider.get_toggles(["some_toggle", "another_toggle"])
+
+        assert (
+            str(error.value) == "The follwing toggles where not found: another_toggle"
         )
-        monkeypatch.setattr(json, "load", json_load_mock)
-        monkeypatch.setattr(json, "dump", json_dump_mock)
-
-        actual_flags = JSONAdapter(path).set_flag("flag_1", False)
-
-        json_dump_mock.assert_called()
-        assert expected_flags == actual_flags
-
-    def test_set_flag_when_file_not_exists_then_returns_new_flags(
-        self, mocker, monkeypatch
-    ):
-        path = "configurations.json"
-        expectred_flags = {"new_flag": True}
-        mocker.patch("builtins.open", new_callable=mock_open())
-        json_load_mock = mocker.Mock(side_effect=FileNotFoundError)
-        monkeypatch.setattr(json, "load", json_load_mock)
-        json_dump_mock = mocker.Mock()
-        monkeypatch.setattr(json, "dump", json_dump_mock)
-
-        actual_flags = JSONAdapter(path).set_flag("new_flag", True)
-
-        json_dump_mock.assert_called()
-        assert expectred_flags == actual_flags


### PR DESCRIPTION
#### 🤔 Why?

- Because the former `FeatureReposirotyAdapter` was meant to be the base class for any ToggleConfiguration providers, which will now adapt to the new contract interface to query the feature toggles

#### 🛠 What I changed:

- Renamed the `factories/adapters.py` to `factories/toggle_configuration.py`
- Replaced the old implementations of `JSONAdapter` and `AWSAppConfigAdapter`  for the new ones, which use the new interface
- Replaced the old test for those implementations for the new ones

#### 🗃️ Jira Issues:

- [FF-22](https://ioetec.atlassian.net/browse/FF-22)

#### 🚦 Functional Testing Results:

![image](https://github.com/ioet/ioet-feature-flag/assets/67567150/ebeaff0e-df2c-43ec-b417-f07a1cca50bd)


[FF-22]: https://ioetec.atlassian.net/browse/FF-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ