### PR TITLE
refactor: FF-52 refactor the toggle router

### DIFF
--- a/ioet_feature_flag/providers/aws_appconfig_toggle_provider.py
+++ b/ioet_feature_flag/providers/aws_appconfig_toggle_provider.py
@@ -3,7 +3,6 @@ import typing
 from ..helpers import AppConfigHelper
 from ..exceptions import ToggleNotFoundError
 from .provider import Provider
-from ..strategies import get_toggle_strategy
 
 
 class AWSAppConfigToggleProvider(Provider):

--- a/ioet_feature_flag/providers/aws_appconfig_toggle_provider.py
+++ b/ioet_feature_flag/providers/aws_appconfig_toggle_provider.py
@@ -15,20 +15,16 @@ class AWSAppConfigToggleProvider(Provider):
             os.environ.get("AWS_APPCONFIG_MAX_CONFIG_AGE", 45),
         )
 
-    def get_toggles(self, toggle_names: typing.List[str]) -> typing.Tuple[bool, ...]:
-        self._appconfig.update_config()
+    def get_toggle_list(self) -> typing.List[str]:
         toggles: typing.Dict = self._appconfig.config
+        return list(toggles.keys())
 
-        missing_toogles = [
-            toggle for toggle in toggle_names if toggle not in toggles
-        ]
-        if missing_toogles:
+    def get_toggle_attributes(self, toggle_name: str) -> typing.Dict:
+        toggles: typing.Dict = self._appconfig.config
+        toggle_attributes = toggles.get(toggle_name)
+        if not toggle_attributes:
             raise ToggleNotFoundError(
-                f"The follwing toggles where not found: {', '.join(missing_toogles)}"
+                f"The toggle {toggle_name} was not found in the"
+                f" {os.environ.get('AWS_APPCONFIG_ENV')} environment."
             )
-
-        return tuple(
-            get_toggle_strategy(toggles.get(toggle_name)).is_enabled()
-            for toggle_name in toggle_names
-            if toggle_name in toggles
-        )
+        return toggle_attributes

--- a/ioet_feature_flag/providers/json_toggle_provider.py
+++ b/ioet_feature_flag/providers/json_toggle_provider.py
@@ -4,7 +4,6 @@ import os
 
 from ..exceptions import ToggleNotFoundError, ToggleEnvironmentError
 from .provider import Provider
-from ..strategies import get_toggle_strategy
 
 
 class JsonToggleProvider(Provider):

--- a/ioet_feature_flag/providers/json_toggle_provider.py
+++ b/ioet_feature_flag/providers/json_toggle_provider.py
@@ -9,28 +9,38 @@ from ..strategies import get_toggle_strategy
 
 class JsonToggleProvider(Provider):
     def __init__(self, toggles_file_path: str) -> None:
-        self.path = toggles_file_path
+        self._path = toggles_file_path
         self._environment = os.getenv("ENVIRONMENT")
+        self._validate_environment()
+
+    def get_toggle_list(self) -> typing.List[str]:
+        with open(self._path, "r") as toggles_file:
+            toggles = json.load(toggles_file)
+            environment_toggles: typing.Dict = toggles[self._environment]
+            return list(environment_toggles.keys())
+
+    def get_toggle_attributes(self, toggle_name: str) -> typing.Dict:
+        with open(self._path, "r") as toggles_file:
+            toggles = json.load(toggles_file)
+            environment_toggles: typing.Dict = toggles.get(self._environment, {})
+            toggle_attributes = environment_toggles.get(toggle_name)
+            if not toggle_attributes:
+                raise ToggleNotFoundError(
+                    f"The toggle {toggle_name} was not found in the"
+                    f" {self._environment} environment."
+                )
+            return toggle_attributes
+
+    def _validate_environment(self):
         if not self._environment:
             raise ToggleEnvironmentError(
-                "Could not retrieve toggles: Toggle environment not specified"
+                "Could not retrieve toggles: Toggle environment not specified."
             )
-
-    def get_toggles(self, toggle_names: typing.List[str]) -> typing.Tuple[bool, ...]:
-        with open(self.path, "r") as toggles_file:
+        with open(self._path, "r") as toggles_file:
             toggles = json.load(toggles_file)
-            environment_toggles = toggles[self._environment]
-
-            missing_toogles = [
-                toggle for toggle in toggle_names if toggle not in environment_toggles
-            ]
-            if missing_toogles:
-                raise ToggleNotFoundError(
-                    f"The follwing toggles where not found: {', '.join(missing_toogles)}"
+            environment_toggles: typing.Dict = toggles.get(self._environment)
+            if not environment_toggles:
+                raise ToggleEnvironmentError(
+                    f"The environment {self._environment} was not found in the"
+                    f" provided {self._path} toggles file."
                 )
-
-            return tuple(
-                get_toggle_strategy(environment_toggles.get(toggle_name)).is_enabled()
-                for toggle_name in toggle_names
-                if toggle_name in environment_toggles
-            )

--- a/ioet_feature_flag/providers/provider.py
+++ b/ioet_feature_flag/providers/provider.py
@@ -4,5 +4,9 @@ import typing
 
 class Provider(abc.ABC):
     @abc.abstractmethod
-    def get_toggles(self, toggle_names: typing.List[str]) -> typing.Tuple[bool, ...]:
+    def get_toggle_list(self) -> typing.List[str]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_toggle_attributes(self, name: str) -> typing.Dict:
         raise NotImplementedError

--- a/ioet_feature_flag/providers/yaml_toggle_provider.py
+++ b/ioet_feature_flag/providers/yaml_toggle_provider.py
@@ -4,7 +4,6 @@ import os
 
 from ..exceptions import ToggleNotFoundError, ToggleEnvironmentError
 from .provider import Provider
-from ..strategies import get_toggle_strategy
 
 
 class YamlToggleProvider(Provider):

--- a/ioet_feature_flag/providers/yaml_toggle_provider.py
+++ b/ioet_feature_flag/providers/yaml_toggle_provider.py
@@ -9,28 +9,38 @@ from ..strategies import get_toggle_strategy
 
 class YamlToggleProvider(Provider):
     def __init__(self, toggles_file_path: str) -> None:
-        self.path = toggles_file_path
+        self._path = toggles_file_path
         self._environment = os.getenv("ENVIRONMENT")
+        self._validate_environment()
+
+    def get_toggle_list(self) -> typing.List[str]:
+        with open(self._path, "r") as toggles_file:
+            toggles = yaml.safe_load(toggles_file)
+            environment_toggles: typing.Dict = toggles[self._environment]
+            return list(environment_toggles.keys())
+
+    def get_toggle_attributes(self, toggle_name: str) -> typing.Dict:
+        with open(self._path, "r") as toggles_file:
+            toggles = yaml.safe_load(toggles_file)
+            environment_toggles: typing.Dict = toggles.get(self._environment, {})
+            toggle_attributes = environment_toggles.get(toggle_name)
+            if not toggle_attributes:
+                raise ToggleNotFoundError(
+                    f"The toggle {toggle_name} was not found in the"
+                    f" {self._environment} environment."
+                )
+            return toggle_attributes
+
+    def _validate_environment(self):
         if not self._environment:
             raise ToggleEnvironmentError(
-                "Could not retrieve toggles: Toggle environment not specified"
+                "Could not retrieve toggles: Toggle environment not specified."
             )
-
-    def get_toggles(self, toggle_names: typing.List[str]) -> typing.Tuple[bool, ...]:
-        with open(self.path, "r") as toggles_file:
+        with open(self._path, "r") as toggles_file:
             toggles = yaml.safe_load(toggles_file)
-            environment_toggles = toggles[self._environment]
-
-            missing_toogles = [
-                toggle for toggle in toggle_names if toggle not in environment_toggles
-            ]
-            if missing_toogles:
-                raise ToggleNotFoundError(
-                    f"The follwing toggles where not found: {', '.join(missing_toogles)}"
+            environment_toggles: typing.Dict = toggles.get(self._environment)
+            if not environment_toggles:
+                raise ToggleEnvironmentError(
+                    f"The environment {self._environment} was not found in the"
+                    f" provided {self._path} toggles file."
                 )
-
-            return tuple(
-                get_toggle_strategy(environment_toggles.get(toggle_name)).is_enabled()
-                for toggle_name in toggle_names
-                if toggle_name in environment_toggles
-            )

--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -8,11 +8,8 @@ _TOGGLES_LOCATION = './feature_toggles/feature-toggles.yaml'
 
 
 class Router:
-    def __init__(self, provider: typing.Optional[Provider]):
-        if provider:
-            self._provider = provider
-            return
-        self._provider = YamlToggleProvider(_TOGGLES_LOCATION)
+    def __init__(self, provider: typing.Optional[Provider] = None):
+        self._provider = provider or YamlToggleProvider(_TOGGLES_LOCATION)
 
     def get_toggles(self, toggle_names: typing.List[str]) -> typing.Tuple[bool, ...]:
         available_toggles = self._provider.get_toggle_list()
@@ -30,12 +27,12 @@ class Router:
             for toggle_name in toggle_names
         ]
 
-        toggle_strategies = [
+        toggle_types = [
             get_toggle_strategy(toggle_attribute)
             for toggle_attribute in toggle_attributes
         ]
 
         return tuple(
             toggle.is_enabled()
-            for toggle in toggle_strategies
+            for toggle in toggle_types
         )

--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -6,13 +6,14 @@ from .strategies import get_toggle_strategy
 
 _TOGGLES_LOCATION = './feature_toggles/feature-toggles.yaml'
 
+
 class Router:
     def __init__(self, provider: typing.Optional[Provider]):
         if provider:
             self._provider = provider
             return
         self._provider = YamlToggleProvider(_TOGGLES_LOCATION)
-    
+
     def get_toggles(self, toggle_names: typing.List[str]) -> typing.Tuple[bool, ...]:
         available_toggles = self._provider.get_toggle_list()
 

--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -1,0 +1,40 @@
+import typing
+
+from .providers import Provider, YamlToggleProvider
+from .exceptions import ToggleNotFoundError
+from .strategies import get_toggle_strategy
+
+_TOGGLES_LOCATION = './feature_toggles/feature-toggles.yaml'
+
+class Router:
+    def __init__(self, provider: typing.Optional[Provider]):
+        if provider:
+            self._provider = provider
+            return
+        self._provider = YamlToggleProvider(_TOGGLES_LOCATION)
+    
+    def get_toggles(self, toggle_names: typing.List[str]) -> typing.Tuple[bool, ...]:
+        available_toggles = self._provider.get_toggle_list()
+
+        missing_toogles = [
+            toggle for toggle in toggle_names if toggle not in available_toggles
+        ]
+        if missing_toogles:
+            raise ToggleNotFoundError(
+                f"The follwing toggles where not found: {', '.join(missing_toogles)}"
+            )
+
+        toggle_attributes = [
+            self._provider.get_toggle_attributes(toggle_name)
+            for toggle_name in toggle_names
+        ]
+
+        toggle_strategies = [
+            get_toggle_strategy(toggle_attribute)
+            for toggle_attribute in toggle_attributes
+        ]
+
+        return tuple(
+            toggle.is_enabled()
+            for toggle in toggle_strategies
+        )

--- a/ioet_feature_flag/strategies/cutover.py
+++ b/ioet_feature_flag/strategies/cutover.py
@@ -11,19 +11,19 @@ class Cutover(Strategy):
         self._date = date
 
     @classmethod
-    def from_metadata(cls, metadata: typing.Dict) -> "Cutover":
-        if not metadata.get("date"):
+    def from_attributes(cls, attributes: typing.Dict) -> "Cutover":
+        if not attributes.get("date"):
             raise MissingToggleAttributes("The toggle type 'cutover' requires a 'date' attribute")
 
         try:
-            date = datetime.datetime.strptime(metadata.get("date"), "%Y-%m-%d %H:%M")
+            date = datetime.datetime.strptime(attributes.get("date"), "%Y-%m-%d %H:%M")
         except ValueError as e:
             raise InvalidToggleAttribute(
                 f"The provided date for the toggle is not valid: {str(e)}."
             )
 
         return cls(
-            enabled=metadata.get('enabled', False),
+            enabled=attributes.get('enabled', False),
             date=date,
         )
 

--- a/ioet_feature_flag/strategies/factory.py
+++ b/ioet_feature_flag/strategies/factory.py
@@ -6,8 +6,8 @@ from .static import Static
 from ..exceptions import InvalidToggleType
 
 
-def get_toggle_strategy(metadata: typing.Dict) -> Strategy:
-    toggle_type = metadata.get('type', 'static')
+def get_toggle_strategy(attributes: typing.Dict) -> Strategy:
+    toggle_type = attributes.get('type', 'static')
     strategies = {
         'static': Static,
         'cutover': Cutover,
@@ -21,4 +21,4 @@ def get_toggle_strategy(metadata: typing.Dict) -> Strategy:
             f" Supported types are {', '.join(allowed_builders)}"
         )
 
-    return strategy.from_metadata(metadata)
+    return strategy.from_attributes(attributes)

--- a/ioet_feature_flag/strategies/static.py
+++ b/ioet_feature_flag/strategies/static.py
@@ -8,9 +8,9 @@ class Static(Strategy):
         self._enabled = enabled
 
     @classmethod
-    def from_metadata(cls, metadata: typing.Dict) -> "Static":
+    def from_attributes(cls, attributes: typing.Dict) -> "Static":
         return cls(
-            enabled=metadata.get('enabled', False),
+            enabled=attributes.get('enabled', False),
         )
 
     def is_enabled(self) -> bool:

--- a/ioet_feature_flag/strategies/strategy.py
+++ b/ioet_feature_flag/strategies/strategy.py
@@ -6,7 +6,7 @@ import typing
 class Strategy(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def from_metadata(cls, metadata: typing.Dict):
+    def from_attributes(cls, attributes: typing.Dict):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -12,8 +12,6 @@ _TOGGLES_LOCATION = './feature_toggles/feature-toggles.yaml'
 
 class Toggles:
     def __init__(self, provider: typing.Optional[Provider] = None) -> None:
-        if not provider:
-            provider = YamlToggleProvider(_TOGGLES_LOCATION)
         self._router = Router(provider)
 
     def toggle_decision(self, decision_function: types.TOOGLE_DECISION):

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -3,11 +3,8 @@ from functools import wraps
 import typing
 
 from . import exceptions, types
-from .providers import Provider, YamlToggleProvider
+from .providers import Provider
 from .router import Router
-
-
-_TOGGLES_LOCATION = './feature_toggles/feature-toggles.yaml'
 
 
 class Toggles:

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -4,6 +4,7 @@ import typing
 
 from . import exceptions, types
 from .providers import Provider, YamlToggleProvider
+from .router import Router
 
 
 _TOGGLES_LOCATION = './feature_toggles/feature-toggles.yaml'
@@ -11,10 +12,9 @@ _TOGGLES_LOCATION = './feature_toggles/feature-toggles.yaml'
 
 class Toggles:
     def __init__(self, provider: typing.Optional[Provider] = None) -> None:
-        if provider:
-            self._provider = provider
-            return
-        self._provider = YamlToggleProvider(_TOGGLES_LOCATION)
+        if not provider:
+            provider = YamlToggleProvider(_TOGGLES_LOCATION)
+        self._router = Router(provider)
 
     def toggle_decision(self, decision_function: types.TOOGLE_DECISION):
         @wraps(decision_function)
@@ -39,6 +39,6 @@ class Toggles:
                     )
                 )
 
-            return decision_function(self._provider.get_toggles, when_on, when_off)
+            return decision_function(self._router.get_toggles, when_on, when_off)
 
         return _wraps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "ioet-feature-flag"
-version = "1.3.1"
+version = "1.3.2"
 description = "Feature Flag library for ioet internal apps"
 authors = ["ioet <info@ioet.com>"]
 readme = "README.md"

--- a/tests/providers/aws_appconfig_toggle_provider_unit_test.py
+++ b/tests/providers/aws_appconfig_toggle_provider_unit_test.py
@@ -75,4 +75,5 @@ class TestGetTogglesMethod:
         with pytest.raises(ToggleNotFoundError) as error:
             toggle_provider.get_toggle_attributes("another_toggle")
 
-        assert str(error.value) == "The toggle another_toggle was not found in the test-env environment."
+        expected_message = "The toggle another_toggle was not found in the test-env environment."
+        assert str(error.value) == expected_message

--- a/tests/providers/aws_appconfig_toggle_provider_unit_test.py
+++ b/tests/providers/aws_appconfig_toggle_provider_unit_test.py
@@ -16,7 +16,7 @@ def _mock_aws_env_variables(monkeypatch):
     monkeypatch.setenv("AWS_APPCONFIG_PROFILE", "test-profile")
 
 
-class TestGetTogglesMethod:
+class TestAWSAppConfigToggleProvider:
     @mock.patch(
         "ioet_feature_flag.providers.aws_appconfig_toggle_provider.AppConfigHelper",
         autospec=True,

--- a/tests/providers/json_toggle_provider_unit_test.py
+++ b/tests/providers/json_toggle_provider_unit_test.py
@@ -32,7 +32,7 @@ def _del_environment(monkeypatch):
         monkeypatch.delenv("ENVIRONMENT")
 
 
-class TestGetTogglesMethod:
+class TestJsonToggleProvider:
     @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
     def test_get_toggle_list(
         self,

--- a/tests/providers/json_toggle_provider_unit_test.py
+++ b/tests/providers/json_toggle_provider_unit_test.py
@@ -93,7 +93,10 @@ class TestGetTogglesMethod:
         with pytest.raises(ToggleNotFoundError) as error:
             toggle_provider.get_toggle_attributes("another_toggle")
 
-        assert str(error.value) == f"The toggle another_toggle was not found in the {environment_name} environment."
+        expected_message = (
+            f"The toggle another_toggle was not found in the {environment_name} environment."
+        )
+        assert str(error.value) == expected_message
 
     def test_validate_no_environment(
         self,
@@ -129,4 +132,8 @@ class TestGetTogglesMethod:
         with pytest.raises(ToggleEnvironmentError) as error:
             JsonToggleProvider(_TOGGLES_FILE)
 
-        assert str(error.value) == f"The environment {environment_name} was not found in the provided {_TOGGLES_FILE} toggles file."
+        expected_message = (
+            f"The environment {environment_name} was not found "
+            f"in the provided {_TOGGLES_FILE} toggles file."
+        )
+        assert str(error.value) == expected_message

--- a/tests/providers/yaml_toggle_provider_unit_test.py
+++ b/tests/providers/yaml_toggle_provider_unit_test.py
@@ -34,7 +34,7 @@ def _del_environment(monkeypatch):
 
 class TestGetTogglesMethod:
     @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
-    def test__returns_the_toggles_specified_in_the_file_when_called_on_environment(
+    def test_get_toggle_list(
         self,
         environment_name: str,
         monkeypatch,
@@ -50,15 +50,12 @@ class TestGetTogglesMethod:
         add_toggles(toggles)
 
         toggle_provider: Provider = YamlToggleProvider(_TOGGLES_FILE)
-        some_toggle, another_toggle = toggle_provider.get_toggles(
-            ["some_toggle", "another_toggle"]
-        )
+        toggle_list = toggle_provider.get_toggle_list()
 
-        assert some_toggle == toggles[environment_name]["some_toggle"]["enabled"]
-        assert another_toggle == toggles[environment_name]["another_toggle"]["enabled"]
+        assert toggle_list == ["another_toggle", "some_toggle"]
 
     @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
-    def test__raises_an_error__if_one_of_the_toggles_does_not_exist(
+    def test_get_toggle_attribute(
         self,
         add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
         environment_name: str,
@@ -73,20 +70,38 @@ class TestGetTogglesMethod:
         add_toggles(toggles)
         toggle_provider: Provider = YamlToggleProvider(_TOGGLES_FILE)
 
+        some_toggle_attributes = toggle_provider.get_toggle_attributes("some_toggle")
+
+        assert some_toggle_attributes == {"enabled": True}
+
+    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
+    def test_get_toggle_attribute_with_invalid_toggle(
+        self,
+        add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
+        environment_name: str,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("ENVIRONMENT", environment_name)
+        toggles = {
+            environment_name: {
+                "some_toggle": {"enabled": True},
+            }
+        }
+        add_toggles(toggles)
+        toggle_provider: Provider = YamlToggleProvider(_TOGGLES_FILE)
+
         with pytest.raises(ToggleNotFoundError) as error:
-            toggle_provider.get_toggles(["some_toggle", "another_toggle"])
+            toggle_provider.get_toggle_attributes("another_toggle")
 
-        assert (
-            str(error.value) == "The follwing toggles where not found: another_toggle"
-        )
+        assert str(error.value) == f"The toggle another_toggle was not found in the {environment_name} environment."
 
-    def test__raises_an_error_when_environment_not_specified(
+    def test_validate_no_environment(
         self,
         add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
     ):
         toggles = {
-            "undefined_env": {
-                "some_toggle": {"enabled": True}
+            "some_env": {
+                "some_toggle": {"enabled": True},
             }
         }
         add_toggles(toggles)
@@ -94,7 +109,24 @@ class TestGetTogglesMethod:
         with pytest.raises(ToggleEnvironmentError) as error:
             YamlToggleProvider(_TOGGLES_FILE)
 
-        assert (
-            str(error.value)
-            == "Could not retrieve toggles: Toggle environment not specified"
-        )
+        assert str(error.value) == "Could not retrieve toggles: Toggle environment not specified."
+
+    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
+    def test_validate_invalid_environment(
+        self,
+        add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
+        environment_name: str,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("ENVIRONMENT", environment_name)
+        toggles = {
+            "some_env": {
+                "some_toggle": {"enabled": True},
+            }
+        }
+        add_toggles(toggles)
+
+        with pytest.raises(ToggleEnvironmentError) as error:
+            YamlToggleProvider(_TOGGLES_FILE)
+
+        assert str(error.value) == f"The environment {environment_name} was not found in the provided {_TOGGLES_FILE} toggles file."

--- a/tests/providers/yaml_toggle_provider_unit_test.py
+++ b/tests/providers/yaml_toggle_provider_unit_test.py
@@ -93,7 +93,10 @@ class TestGetTogglesMethod:
         with pytest.raises(ToggleNotFoundError) as error:
             toggle_provider.get_toggle_attributes("another_toggle")
 
-        assert str(error.value) == f"The toggle another_toggle was not found in the {environment_name} environment."
+        expected_message = (
+            f"The toggle another_toggle was not found in the {environment_name} environment."
+        )
+        assert str(error.value) == expected_message
 
     def test_validate_no_environment(
         self,
@@ -129,4 +132,8 @@ class TestGetTogglesMethod:
         with pytest.raises(ToggleEnvironmentError) as error:
             YamlToggleProvider(_TOGGLES_FILE)
 
-        assert str(error.value) == f"The environment {environment_name} was not found in the provided {_TOGGLES_FILE} toggles file."
+        expected_message = (
+            f"The environment {environment_name} was not found "
+            f"in the provided {_TOGGLES_FILE} toggles file."
+        )
+        assert str(error.value) == expected_message

--- a/tests/providers/yaml_toggle_provider_unit_test.py
+++ b/tests/providers/yaml_toggle_provider_unit_test.py
@@ -32,7 +32,7 @@ def _del_environment(monkeypatch):
         monkeypatch.delenv("ENVIRONMENT")
 
 
-class TestGetTogglesMethod:
+class TestYamlToggleProvider:
     @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
     def test_get_toggle_list(
         self,

--- a/tests/router_unit_test.py
+++ b/tests/router_unit_test.py
@@ -3,8 +3,8 @@ import pytest
 import os
 import typing
 
-from ioet_feature_flag.providers import YamlToggleProvider, Provider
-from ioet_feature_flag.exceptions import ToggleNotFoundError, ToggleEnvironmentError
+from ioet_feature_flag.providers import YamlToggleProvider
+from ioet_feature_flag.exceptions import ToggleNotFoundError
 from ioet_feature_flag.router import Router
 
 _TOGGLES_FILE = "/tmp/app_toggles_test.yaml"

--- a/tests/router_unit_test.py
+++ b/tests/router_unit_test.py
@@ -1,0 +1,84 @@
+import yaml
+import pytest
+import os
+import typing
+
+from ioet_feature_flag.providers import YamlToggleProvider, Provider
+from ioet_feature_flag.exceptions import ToggleNotFoundError, ToggleEnvironmentError
+from ioet_feature_flag.router import Router
+
+_TOGGLES_FILE = "/tmp/app_toggles_test.yaml"
+
+
+@pytest.fixture(autouse=True)
+def _clear_toggles_file():
+    yield
+    if os.path.exists(_TOGGLES_FILE):
+        os.remove(_TOGGLES_FILE)
+
+
+@pytest.fixture(name="add_toggles")
+def _add_toggles():
+    def _add(toggles: typing.Dict[str, typing.Dict[str, bool]]) -> None:
+        with open(_TOGGLES_FILE, "w") as toggles_file:
+            yaml.dump(toggles, toggles_file)
+
+    return _add
+
+
+@pytest.fixture(autouse=True)
+def _del_environment(monkeypatch):
+    yield
+    if os.getenv("ENVIRONMENT"):
+        monkeypatch.delenv("ENVIRONMENT")
+
+
+class TestGetTogglesMethod:
+    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
+    def test__returns_the_toggles_specified_in_the_file_when_called_on_environment(
+        self,
+        environment_name: str,
+        monkeypatch,
+        add_toggles: typing.Callable[[typing.Dict[str, typing.Dict[str, bool]]], None],
+    ):
+        monkeypatch.setenv("ENVIRONMENT", environment_name)
+        toggles = {
+            environment_name: {
+                "some_toggle": {"enabled": True},
+                "another_toggle": {"enabled": False}
+            }
+        }
+        add_toggles(toggles)
+
+        toggle_provider = YamlToggleProvider(_TOGGLES_FILE)
+        toggle_router = Router(toggle_provider)
+        some_toggle, another_toggle = toggle_router.get_toggles(
+            ["some_toggle", "another_toggle"]
+        )
+
+        assert some_toggle == toggles[environment_name]["some_toggle"]["enabled"]
+        assert another_toggle == toggles[environment_name]["another_toggle"]["enabled"]
+
+    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
+    def test__raises_an_error__if_one_of_the_toggles_does_not_exist(
+        self,
+        add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
+        environment_name: str,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("ENVIRONMENT", environment_name)
+        toggles = {
+            environment_name: {
+                "some_toggle": {"enabled": True}
+            }
+        }
+        add_toggles(toggles)
+        toggle_provider = YamlToggleProvider(_TOGGLES_FILE)
+        toggle_router = Router(toggle_provider)
+
+        with pytest.raises(ToggleNotFoundError) as error:
+            toggle_router.get_toggles(["some_toggle", "another_toggle"])
+
+        assert (
+            str(error.value) == "The follwing toggles where not found: another_toggle"
+        )

--- a/tests/strategies/cutover_unit_test.py
+++ b/tests/strategies/cutover_unit_test.py
@@ -20,21 +20,21 @@ class TestCutoverStrategy:
         ]
     )
     @freeze_time("2023-08-20 14:00:00", tz_offset=-4)
-    def test__returns_toggles_specified_in_metadata(
+    def test__returns_toggles_specified_in_attributes(
         self,
         is_enabled,
         date,
         expected_result,
         expected_exception,
     ):
-        metadata = {
+        attributes = {
             "enabled": is_enabled,
             "type": "cutover",
             "date": date,
         }
         if expected_exception:
             with pytest.raises(expected_exception):
-                Cutover.from_metadata(metadata)
+                Cutover.from_attributes(attributes)
         else:
-            cutover_strategy = Cutover.from_metadata(metadata)
+            cutover_strategy = Cutover.from_attributes(attributes)
             assert cutover_strategy.is_enabled() == expected_result

--- a/tests/strategies/factory_unit_test.py
+++ b/tests/strategies/factory_unit_test.py
@@ -8,18 +8,18 @@ from ioet_feature_flag.exceptions import InvalidToggleType
 
 
 @pytest.mark.parametrize(
-    "metadata, expected_result, expected_exception",
+    "attributes, expected_result, expected_exception",
     [
         ({"type": "static"}, Static, None),
         ({"type": "cutover", "date": "2023-08-21 08:00"}, Cutover, None),
         ({"type": "non_existent_type"}, None, InvalidToggleType),
     ]
 )
-def test_get_toggle_strategy(metadata, expected_result, expected_exception):
-    metadata["enabled"] = True
+def test_get_toggle_strategy(attributes, expected_result, expected_exception):
+    attributes["enabled"] = True
     if expected_exception:
         with pytest.raises(expected_exception):
-            get_toggle_strategy(metadata)
+            get_toggle_strategy(attributes)
     else:
-        strategy = get_toggle_strategy(metadata)
+        strategy = get_toggle_strategy(attributes)
         assert isinstance(strategy, expected_result)

--- a/tests/strategies/static_unit_test.py
+++ b/tests/strategies/static_unit_test.py
@@ -5,13 +5,13 @@ from ioet_feature_flag.strategies import Static
 
 class TestStaticStrategy:
     @pytest.mark.parametrize("is_enabled", [True, False])
-    def test__returns_toggles_specified_in_metadata(
+    def test__returns_toggles_specified_in_attributes(
         self,
         is_enabled,
     ):
-        metadata = {
+        attributes = {
             "enabled": is_enabled,
             "type": "static",
         }
-        static_strategy = Static.from_metadata(metadata)
+        static_strategy = Static.from_attributes(attributes)
         assert static_strategy.is_enabled() == is_enabled

--- a/tests/toggles_unit_test.py
+++ b/tests/toggles_unit_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from ioet_feature_flag import Toggles
 from ioet_feature_flag.exceptions import InvalidDecisionFunction
+from ioet_feature_flag.router import Router
 
 
 class TestTogglesDecisionMethod:
@@ -9,13 +10,22 @@ class TestTogglesDecisionMethod:
         provider = mocker.Mock()
         when_on = mocker.Mock()
         when_off = mocker.Mock()
+        get_toggles = mocker.Mock()
+        router = mocker.create_autospec(
+            Router,
+            get_toggles=get_toggles
+        )
+        mocker.patch(
+            "ioet_feature_flag.toggles.Router",
+            return_value=router,
+        )
         decision_function = mocker.Mock(return_value=when_on)
         toggles = Toggles(provider=provider)
 
         decision = toggles.toggle_decision(decision_function)
         decided_value = decision(when_on=when_on, when_off=when_off)
 
-        decision_function.assert_called_with(provider.get_toggles, when_on, when_off)
+        decision_function.assert_called_with(router.get_toggles, when_on, when_off)
         assert decided_value == when_on
 
     def test__raises_an_error_when_toggle_values_are_from_different_types(self, mocker):


### PR DESCRIPTION
#### 🤔 Why?

- Avoid giving the provider the responsibility of getting the toggle context and toggle strategies.

#### 🛠 What I changed:

- A toggle router class was created with the same signature that the toggle provider used to have. And not toggle providers are only responsible of getting the toggle attributes and the list of available toggles.

#### 🗃️ Jira Issues:

- [FF-52](https://ioetec.atlassian.net/browse/FF-52)


[FF-52]: https://ioetec.atlassian.net/browse/FF-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ