### PR TITLE
fix: FF-56 updated script to pull from current branch

### DIFF
--- a/scripts/test_import/test-import.sh
+++ b/scripts/test_import/test-import.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eo pipefail
+
 function test_import() {
     cd ../
     poetry new test-project && cd test-project

--- a/scripts/test_import/test-import.sh
+++ b/scripts/test_import/test-import.sh
@@ -2,9 +2,10 @@
 set -eo pipefail
 
 function test_import() {
+    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
     cd ../
     poetry new test-project && cd test-project
-    poetry add git+https://git@github.com/ioet/ioet-feature-flag.git
+    poetry add git+https://git@github.com/ioet/ioet-feature-flag.git@$CURRENT_BRANCH
     poetry add pytest
     export ENVIRONMENT="test"
     cp -r ../ioet-feature-flag/scripts/test_import/* ./


### PR DESCRIPTION
#### 🤔 Why?

- Since the script is passing but if the test inside of it fails, it's not shown in the pipeline

#### 🛠 What I changed:

- Added shebang in the script
- Added a variable to get the current branch so that the test imports the library from the current branch

#### 🗃️ Jira Issues:

- [FF-56](https://ioetec.atlassian.net/browse/FF-56)

#### 🚦 Functional Testing Results:

N/A


[FF-56]: https://ioetec.atlassian.net/browse/FF-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ