### PR TITLE
fix: FF-53 added context to dummy module for testing library import

### DIFF
--- a/scripts/test_import/dummy_module.py
+++ b/scripts/test_import/dummy_module.py
@@ -4,8 +4,8 @@ toggles = ioet_feature_flag.Toggles()
 
 
 @toggles.toggle_decision
-def dummy_decision(get_toggles, when_on, when_off):
-    is_enabled = get_toggles(["dummy-flag"])
+def dummy_decision(get_toggles, when_on, when_off, context=None):
+    is_enabled = get_toggles(["dummy-flag"], context)
     if is_enabled:
         return when_on
     return when_off


### PR DESCRIPTION
#### 🤔 Why?

- Because the library import test failed when #30 was merged.

#### 🛠 What I changed:

- Added the context argument on the dummy module

#### 🗃️ Jira Issues:

- [FF-53](https://ioetec.atlassian.net/browse/FF-53)

#### 🚦 Functional Testing Results:

![image](https://github.com/ioet/ioet-feature-flag/assets/67567150/39ea5805-806c-4ad3-9a49-da83d2f926f7)



[FF-53]: https://ioetec.atlassian.net/browse/FF-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ