### PR TITLE
feat: FF-58 protect the main branch with codeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+[README Owners]
+
+README.md @Mikkel-14 @FranLMSP @Rouderz
+
+[Folder Owners]
+
+.github/ @Mikkel-14 @FranLMSP @Rouderz
+ioet_feature_flag/ @Mikkel-14 @FranLMSP @Rouderz
+release_version_tools/ @Mikkel-14 @FranLMSP @Rouderz
+scripts/ @Mikkel-14 @FranLMSP @Rouderz
+tests/ @Mikkel-14 @FranLMSP @Rouderz
+
+[File Owners]
+
+.flake8 @Mikkel-14 @FranLMSP @Rouderz
+.gitignore @Mikkel-14 @FranLMSP @Rouderz
+CHANGELOG.md @Mikkel-14 @FranLMSP @Rouderz
+poetry.lock @Mikkel-14 @FranLMSP @Rouderz
+pyproject.toml @Mikkel-14 @FranLMSP @Rouderz
+pytest.ini @Mikkel-14 @FranLMSP @Rouderz
+.devcontainer/Dockerfile @Mikkel-14 @FranLMSP @Rouderz


### PR DESCRIPTION
#### 🤔 Why?

- The goal of this ticket is to Prevent someone from running git push locally directly to the main branch, potentially pushing something malicious.

#### 🛠 What I changed:

- Added CodeOwner File

#### 🗃️ Jira Issues:

- [Ticket](https://ioetec.atlassian.net/jira/core/projects/FF/board?selectedIssue=FF-58)

#### 🚦 Functional Testing Results:

- **API**: list of tests performed, using bullet points and/or screenshots as needed (i.e., "Functionally tested Checkout on localhost" or "Here is the script output results")

- **UI**: add "before" and "after" screenshots of the affected UI - if multiple browsers had to be tested, include a checklist of those
