### PR TITLE
docs: FF-64 update readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,12 @@ Moreover, we are planning to support [AWS AppConfig](https://docs.aws.amazon.com
 ## Installation
 We are currently supporting Python version 3.9 as the minimum version required to install this library, as it is the oldest python version that our Internal Apps use.
 
-We recommend installing this library with [Poetry](https://python-poetry.org/) (you can find more about installing dependencies with poetry [here](https://python-poetry.org/docs/cli/#add)).
-
-To install an specific version (recommended):
+To install with Poetry:
 ```shell
 poetry add git+https://github.com/ioet/ioet-feature-flag.git@<branch-or-tag>
 ```
 
-To install an specific version using `pip`:
+To install with `pip`:
 ```shell
 pip install git+https://github.com/ioet/ioet-feature-flag.git@<branch-or-tag>
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install with `pip`:
 pip install git+https://github.com/ioet/ioet-feature-flag.git@<branch-or-tag>
 ```
 
-It is also possible to install with SSH instead of HTTPS by simply replacing `https://github.com` by `ssh://git@github.com`, although we recommend using SSH instead.
+It is also possible to install with SSH instead of HTTPS by simply replacing `https://github.com` by `ssh://git@github.com`.
 Example:
 ```shell
 poetry add git+ssh://git@github.com/ioet/ioet-feature-flag.git#<branch-or-tag>

--- a/README.md
+++ b/README.md
@@ -14,25 +14,19 @@ We recommend installing this library with [Poetry](https://python-poetry.org/) (
 
 To install an specific version (recommended):
 ```shell
-poetry add git+ssh://git@github.com/ioet/ioet-feature-flag.git#<branch-or-tag>
-```
-
-To install the latest version:
-```shell
-poetry add git+ssh://git@github.com/ioet/ioet-feature-flag.git
+poetry add git+https://github.com/ioet/ioet-feature-flag.git@<branch-or-tag>
 ```
 
 To install an specific version using `pip`:
 ```shell
-pip install git+ssh://git@github.com/ioet/ioet-feature-flag.git@<branch-or-tag>
+pip install git+https://github.com/ioet/ioet-feature-flag.git@<branch-or-tag>
 ```
 
-To install the latest version using `pip`:
+It is also possible to install with SSH instead of HTTPS by simply replacing `https://github.com` by `ssh://git@github.com`, although we recommend using SSH instead.
+Example:
 ```shell
-pip install git+ssh://git@github.com/ioet/ioet-feature-flag.git
+poetry add git+ssh://git@github.com/ioet/ioet-feature-flag.git#<branch-or-tag>
 ```
-
-It is also possible to install with HTTPS instead of SSH by simply replacing `ssh://git@github.com` by `https://github.com`, although we recommend using SSH instead.
 
 If you want to, you can also clone this repository locally and install the library by specifying the folder in which the repo was cloned
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "ioet-feature-flag"
-version = "1.5.0"
+version = "1.5.1"
 description = "Feature Flag library for ioet internal apps"
 authors = ["ioet <info@ioet.com>"]
 readme = "README.md"


### PR DESCRIPTION
#### 🤔 Why?

- Since the repo is now public, update the documentation so users install the repo using HTTP by default

#### 🛠 What I changed:

- Updated README.md accordingly. Also, removed a couple of steps just to reduce a bit of noise in the docs and make it less confusing

#### 🗃️ Jira Issues:

- [FF-64](https://ioetec.atlassian.net/browse/FF-64)



[FF-64]: https://ioetec.atlassian.net/browse/FF-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ