### PR TITLE
feat: FF-67: get_all_toggles method

### DIFF
--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -40,3 +40,24 @@ class Router:
         return tuple(
             toggle.is_enabled(context=toggle_context) for toggle in toggle_types
         )
+
+    def get_all_toggles(
+        self,
+        context: typing.Optional[ToggleContext] = None,
+    ):
+        available_toggles = self._provider.get_toggle_list()
+
+        raw_toggles = {
+            toggle_name: self._provider.get_toggle_attributes(toggle_name)
+            for toggle_name in available_toggles
+        }
+
+        toggle_types = {
+            toggle_name: get_toggle_strategy(toggle_attributes)
+            for toggle_name, toggle_attributes in raw_toggles.items()
+        }
+
+        return {
+            toggle_name: toggle.is_enabled(context=context)
+            for toggle_name, toggle in toggle_types.items()
+        }

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -41,3 +41,9 @@ class Toggles:
             )
 
         return _wraps
+
+    def get_all_toggles(
+        self,
+        context: typing.Optional[ToggleContext] = None,
+    ):
+        return self._router.get_all_toggles(context)


### PR DESCRIPTION
#### 🤔 Why?

- We need a method to get the state of all the available toggles

#### 🛠 What I changed:

- Created a `get_all_toggles` method for the router

#### 🗃️ Jira Issues:

- [FF-67](https://ioetec.atlassian.net/browse/FF-67)



[FF-67]: https://ioetec.atlassian.net/browse/FF-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ