### PR TITLE
refactor: FF-62 refactored unit tests to use mocks

### DIFF
--- a/tests/router_unit_test.py
+++ b/tests/router_unit_test.py
@@ -1,76 +1,53 @@
-import yaml
 import pytest
-import os
 import typing
 
-from ioet_feature_flag.providers import YamlToggleProvider
 from ioet_feature_flag.exceptions import ToggleNotFoundError
 from ioet_feature_flag.router import Router
 
-_TOGGLES_FILE = "/tmp/app_toggles_test.yaml"
-
-
-@pytest.fixture(autouse=True)
-def _clear_toggles_file():
-    yield
-    if os.path.exists(_TOGGLES_FILE):
-        os.remove(_TOGGLES_FILE)
-
-
-@pytest.fixture(name="add_toggles")
-def _add_toggles():
-    def _add(toggles: typing.Dict[str, typing.Dict[str, bool]]) -> None:
-        with open(_TOGGLES_FILE, "w") as toggles_file:
-            yaml.dump(toggles, toggles_file)
-
-    return _add
-
-
-@pytest.fixture(autouse=True)
-def _del_environment(monkeypatch):
-    yield
-    if os.getenv("ENVIRONMENT"):
-        monkeypatch.delenv("ENVIRONMENT")
-
 
 class TestGetTogglesMethod:
-    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
+    @pytest.fixture(name="dependency_factory")
+    def __dependency_factory(self, mocker) -> typing.Callable:
+        def _factory(toggle_values: typing.Dict):
+            toggle_names = toggle_values.keys()
+            return {
+                "provider": mocker.Mock(
+                    get_toggle_list=mocker.Mock(return_value=list(toggle_names)),
+                    get_toggle_attributes=mocker.Mock(
+                        side_effect=[
+                            toggle_values[toggle_name] for toggle_name in toggle_names
+                        ]
+                    ),
+                )
+            }
+
+        return _factory
+
     def test__returns_the_toggles_specified_in_the_file_when_called_on_environment(
         self,
-        environment_name: str,
-        monkeypatch,
-        add_toggles: typing.Callable[[typing.Dict[str, typing.Dict[str, bool]]], None],
+        dependency_factory: typing.Callable,
     ):
-        monkeypatch.setenv("ENVIRONMENT", environment_name)
         toggles = {
-            environment_name: {
-                "some_toggle": {"enabled": True},
-                "another_toggle": {"enabled": False},
-            }
+            "some_toggle": {"enabled": True},
+            "another_toggle": {"enabled": False},
         }
-        add_toggles(toggles)
 
-        toggle_provider = YamlToggleProvider(_TOGGLES_FILE)
-        toggle_router = Router(toggle_provider)
+        dependencies = dependency_factory(toggle_values=toggles)
+        toggle_router = Router(**dependencies)
         some_toggle, another_toggle = toggle_router.get_toggles(
             ["some_toggle", "another_toggle"]
         )
 
-        assert some_toggle == toggles[environment_name]["some_toggle"]["enabled"]
-        assert another_toggle == toggles[environment_name]["another_toggle"]["enabled"]
+        assert some_toggle == toggles["some_toggle"]["enabled"]
+        assert another_toggle == toggles["another_toggle"]["enabled"]
 
-    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
     def test__raises_an_error__if_one_of_the_toggles_does_not_exist(
         self,
-        add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
-        environment_name: str,
-        monkeypatch,
+        dependency_factory: typing.Callable,
     ):
-        monkeypatch.setenv("ENVIRONMENT", environment_name)
-        toggles = {environment_name: {"some_toggle": {"enabled": True}}}
-        add_toggles(toggles)
-        toggle_provider = YamlToggleProvider(_TOGGLES_FILE)
-        toggle_router = Router(toggle_provider)
+        toggles = {"some_toggle": {"enabled": True}}
+        dependencies = dependency_factory(toggle_values=toggles)
+        toggle_router = Router(**dependencies)
 
         with pytest.raises(ToggleNotFoundError) as error:
             toggle_router.get_toggles(["some_toggle", "another_toggle"])
@@ -79,25 +56,20 @@ class TestGetTogglesMethod:
             str(error.value) == "The follwing toggles where not found: another_toggle"
         )
 
-    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
     def test__uses_the_toggle_context_when_it_is_provided(
         self,
         mocker,
-        monkeypatch,
-        add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
-        environment_name: str,
+        dependency_factory: typing.Callable,
     ):
-        monkeypatch.setenv("ENVIRONMENT", environment_name)
-        toggles = {environment_name: {"some_toggle": {"enabled": True}}}
-        add_toggles(toggles)
+        toggles = {"some_toggle": {"enabled": True}}
         toggle_strategy = mocker.Mock(is_enabled=mocker.Mock(return_value=True))
         toggle_context = mocker.Mock()
         mocker.patch(
             "ioet_feature_flag.router.get_toggle_strategy",
             return_value=toggle_strategy,
         )
-        toggle_provider = YamlToggleProvider(_TOGGLES_FILE)
-        toggle_router = Router(toggle_provider)
+        dependencies = dependency_factory(toggle_values=toggles)
+        toggle_router = Router(**dependencies)
 
         toggle_router.get_toggles(["some_toggle"], toggle_context)
 

--- a/tests/strategies/pilot_users_unit_test.py
+++ b/tests/strategies/pilot_users_unit_test.py
@@ -1,42 +1,60 @@
+import typing
+
 import pytest
 
 from ioet_feature_flag.strategies import PilotUsers
 from ioet_feature_flag.exceptions import MissingToggleAttributes
-from ioet_feature_flag.toggle_context import ToggleContext
 
 
 class TestPilotUsersStrategy:
+    @pytest.fixture
+    def dependency_factory(self, mocker):
+        def _factory(**context_attributes: typing.Dict):
+            return {
+                "toggle_context": mocker.Mock(
+                    username=context_attributes.get("username", "default_user"),
+                    role=context_attributes.get("role", "default"),
+                )
+            }
+
+        return _factory
+
     @pytest.mark.parametrize(
         "is_enabled, current_user, allowed_users, expected_result, expected_exception",
         [
-            (True, 'allowed_user', '', False, MissingToggleAttributes),
-            (True, 'allowed_user', 'allowed_user', True, None),
-            (True, 'allowed_user', 'allowed_user,another_user', True, None),
-            (False, 'allowed_user', 'allowed_user', False, None),
-            (False, 'allowed_user', 'allowed_user,another_user', False, None),
-            (True, 'not_allowed_user', 'allowed_user', False, None),
-            (True, 'not_allowed_user', 'allowed_user,another_user', False, None),
-            (False, 'not_allowed_user', 'allowed_user', False, None),
-            (False, 'not_allowed_user', 'allowed_user,another_user', False, None),
-        ]
+            (True, "allowed_user", "", False, MissingToggleAttributes),
+            (True, "allowed_user", "allowed_user", True, None),
+            (True, "allowed_user", "allowed_user,another_user", True, None),
+            (False, "allowed_user", "allowed_user", False, None),
+            (False, "allowed_user", "allowed_user,another_user", False, None),
+            (True, "not_allowed_user", "allowed_user", False, None),
+            (True, "not_allowed_user", "allowed_user,another_user", False, None),
+            (False, "not_allowed_user", "allowed_user", False, None),
+            (False, "not_allowed_user", "allowed_user,another_user", False, None),
+        ],
     )
     def test__returns_toggles_specified_in_attributes(
         self,
-        is_enabled,
-        current_user,
-        allowed_users,
-        expected_result,
-        expected_exception,
+        is_enabled: bool,
+        current_user: str,
+        allowed_users: str,
+        expected_result: bool,
+        expected_exception: typing.Any,
+        dependency_factory: typing.Callable,
     ):
         attributes = {
             "enabled": is_enabled,
             "type": "pilot_users",
             "allowed_users": allowed_users,
         }
-        toggle_context = ToggleContext(username=current_user, role="default")
+        toggle_context = dependency_factory(username=current_user)["toggle_context"]
+
         if expected_exception:
             with pytest.raises(expected_exception):
                 PilotUsers.from_attributes(attributes)
         else:
             pilot_users_strategy = PilotUsers.from_attributes(attributes)
-            assert pilot_users_strategy.is_enabled(context=toggle_context) == expected_result
+            assert (
+                pilot_users_strategy.is_enabled(context=toggle_context)
+                == expected_result
+            )


### PR DESCRIPTION
#### 🤔 Why?

- Because unit tests should be isolated and not use actual dependency implementations

#### 🛠 What I changed:

- Refactored the router unit test to include a dependency factory fixture and use mocks to inject to the router class being tested
- Added a dependency factory fixture on the pilot users unit test to mock a toggle context

#### 🗃️ Jira Issues:

[FF-62](https://ioetec.atlassian.net/browse/FF-62)

#### 🚦 Functional Testing Results:

![image](https://github.com/ioet/ioet-feature-flag/assets/67567150/c0de6394-4c90-4254-bc6f-15934f8bb79a)


[FF-62]: https://ioetec.atlassian.net/browse/FF-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ