### PR TITLE
fix: FF-74 removed semantic release from CI pipeline

### DIFF
--- a/.github/workflows/feature-flag-general.yaml
+++ b/.github/workflows/feature-flag-general.yaml
@@ -1,4 +1,4 @@
-name: Feature-Flag-Continues-Integration
+name: Feature-Flag-Continuous-Integration
 
 on:
     push:
@@ -74,11 +74,3 @@ jobs:
 
             - name: Test library import
               run: ./scripts/test_import/test-import.sh
-
-            - name: Python Semantic Release
-              if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-              run: |
-                pip install python-semantic-release==7.34.6
-                git config --global user.name "github-actions"
-                git config --global user.email "action@github.com"
-                DEBUG='semantic_release.*' semantic-release publish -D commit_author="github-actions <action@github.com>"

--- a/scripts/test_import/test-import.sh
+++ b/scripts/test_import/test-import.sh
@@ -2,10 +2,9 @@
 set -eo pipefail
 
 function test_import_poetry() {
-    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
     cd ../
     poetry new test-project-poetry && cd test-project-poetry
-    poetry add git+https://git@github.com/ioet/ioet-feature-flag.git@$CURRENT_BRANCH
+    poetry add git+https://git@github.com/ioet/ioet-feature-flag.git@$1
     poetry add pytest
     export ENVIRONMENT="test"
     cp -r ../ioet-feature-flag/scripts/test_import/* ./
@@ -15,11 +14,10 @@ function test_import_poetry() {
 }
 
 function test_import_pip() {
-    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
     cd ../
     mkdir test-project-pip && cd test-project-pip
     python -m venv env && source env/bin/activate
-    pip install git+https://github.com/ioet/ioet-feature-flag.git@$CURRENT_BRANCH
+    pip install git+https://github.com/ioet/ioet-feature-flag.git@$1
     pip install -U pytest
     export ENVIRONMENT="test"
     cp -r ../ioet-feature-flag/scripts/test_import/* ./
@@ -27,5 +25,6 @@ function test_import_pip() {
     cd ../ioet-feature-flag
 }
 
-test_import_poetry
-test_import_pip
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+test_import_poetry $CURRENT_BRANCH
+test_import_pip $CURRENT_BRANCH


### PR DESCRIPTION
#### 🤔 Why?

- Becaue se the CI pipeline has been failing due to python semantic release step not being able to push to the main branch. Also the test library import script was failing when trying to get the current branch commit hash

#### 🛠 What I changed:

- Removed python semantic release from CI pipeline due to commit restrictions on main branch
- Refactored test import shell script to query the current branch just once

#### 🗃️ Jira Issues:

- [FF-74](https://ioetec.atlassian.net/browse/FF-74)

#### 🚦 Functional Testing Results:

N/A


[FF-74]: https://ioetec.atlassian.net/browse/FF-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ