### PR TITLE
refactor: FF-73 refactor pilot users to be a list

### DIFF
--- a/ioet_feature_flag/strategies/pilot_users.py
+++ b/ioet_feature_flag/strategies/pilot_users.py
@@ -1,7 +1,7 @@
 import typing
 
 from .strategy import Strategy
-from ..exceptions import MissingToggleAttributes
+from ..exceptions import MissingToggleAttributes, InvalidToggleAttribute
 from ..toggle_context import ToggleContext
 
 
@@ -12,13 +12,16 @@ class PilotUsers(Strategy):
 
     @classmethod
     def from_attributes(cls, attributes: typing.Dict) -> "PilotUsers":
-        allowed_users: str = attributes.get('allowed_users')
+        allowed_users: typing.List[str] = attributes.get("allowed_users")
         if not allowed_users:
             raise MissingToggleAttributes("You must provide a list of allowed users")
 
+        if not isinstance(allowed_users, list):
+            raise InvalidToggleAttribute("The provided users must be in a list")
+
         return cls(
-            enabled=attributes.get('enabled', False),
-            allowed_users=allowed_users.split(','),
+            enabled=attributes.get("enabled", False),
+            allowed_users=[user.strip() for user in allowed_users],
         )
 
     def is_enabled(self, context: ToggleContext) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "ioet-feature-flag"
-version = "1.5.1"
+version = "1.6.0"
 description = "Feature Flag library for ioet internal apps"
 authors = ["ioet <info@ioet.com>"]
 readme = "README.md"

--- a/scripts/test_import/dummy_module.py
+++ b/scripts/test_import/dummy_module.py
@@ -11,8 +11,27 @@ def dummy_decision(get_toggles, when_on, when_off, context=None):
     return when_off
 
 
+@toggles.toggle_decision
+def dummy_decision_user(get_toggles, when_on, when_off, context=None):
+    is_enabled = get_toggles(["user-dummy-flag"], context)
+    if is_enabled:
+        return when_on
+    return when_off
+
+
 def get_name():
     return dummy_decision(
         when_on="name-a",
         when_off="name-b",
+    )
+
+
+def get_name_user():
+    return dummy_decision_user(
+        when_on="name-a",
+        when_off="name-b",
+        context=ioet_feature_flag.ToggleContext(
+            username="test_user",
+            role="",
+        ),
     )

--- a/scripts/test_import/dummy_test.py
+++ b/scripts/test_import/dummy_test.py
@@ -3,3 +3,7 @@ import dummy_module
 
 def test_get_name():
     assert dummy_module.get_name() == "name-a"
+
+
+def test_get_name_user():
+    assert dummy_module.get_name_user() == "name-a"

--- a/scripts/test_import/feature_toggles/feature-toggles.yaml
+++ b/scripts/test_import/feature_toggles/feature-toggles.yaml
@@ -2,3 +2,9 @@ test:
     dummy-flag:
         enabled: true
         type: static
+    user-dummy-flag:
+        enabled: true
+        type: pilot_users
+        allowed_users:
+            - test_user
+            - another_user

--- a/tests/router_unit_test.py
+++ b/tests/router_unit_test.py
@@ -77,44 +77,37 @@ class TestGetTogglesMethod:
 
         toggle_strategy.is_enabled.assert_called_with(context=toggle_context)
 
-    @pytest.mark.parametrize("environment_name", [("production"), ("stage")])
     @freeze_time("2023-08-20 14:00:00", tz_offset=-4)
     def test__get_all_toggles(
         self,
-        monkeypatch,
-        add_toggles: typing.Callable[[typing.Dict[str, bool]], None],
-        environment_name: str,
+        dependency_factory: typing.Callable,
     ):
-        monkeypatch.setenv("ENVIRONMENT", environment_name)
         toggles = {
-            environment_name: {
-                "some_toggle": {"enabled": True},
-                "another_toggle": {"enabled": False},
-                "pilot_users_toggle": {
-                    "enabled": True,
-                    "type": "pilot_users",
-                    "allowed_users": "test_user,another_user"
-                },
-                "another_pilot_users_toggle": {
-                    "enabled": True,
-                    "type": "pilot_users",
-                    "allowed_users": "another_user"
-                },
-                "cutover_strategy": {
-                    "enabled": True,
-                    "type": "cutover",
-                    "date": "2023-08-20 10:00"
-                },
-                "another_cutover_strategy": {
-                    "enabled": True,
-                    "type": "cutover",
-                    "date": "2023-08-20 16:00"
-                },
-            }
+            "some_toggle": {"enabled": True},
+            "another_toggle": {"enabled": False},
+            "pilot_users_toggle": {
+                "enabled": True,
+                "type": "pilot_users",
+                "allowed_users": ["test_user", "another_user"],
+            },
+            "another_pilot_users_toggle": {
+                "enabled": True,
+                "type": "pilot_users",
+                "allowed_users": ["another_user"]
+            },
+            "cutover_strategy": {
+                "enabled": True,
+                "type": "cutover",
+                "date": "2023-08-20 10:00"
+            },
+            "another_cutover_strategy": {
+                "enabled": True,
+                "type": "cutover",
+                "date": "2023-08-20 16:00"
+            },
         }
-        add_toggles(toggles)
-        toggle_provider = YamlToggleProvider(_TOGGLES_FILE)
-        toggle_router = Router(toggle_provider)
+        dependencies = dependency_factory(toggle_values=toggles)
+        toggle_router = Router(**dependencies)
         context = ToggleContext(username="test_user", role="")
 
         result = toggle_router.get_all_toggles(context=context)

--- a/tests/strategies/factory_unit_test.py
+++ b/tests/strategies/factory_unit_test.py
@@ -11,7 +11,7 @@ from ioet_feature_flag.exceptions import InvalidToggleType
     [
         ({"type": "static"}, Static, None),
         ({"type": "cutover", "date": "2023-08-21 08:00"}, Cutover, None),
-        ({"type": "pilot_users", "allowed_users": "test"}, PilotUsers, None),
+        ({"type": "pilot_users", "allowed_users": ["test"]}, PilotUsers, None),
         ({"type": "non_existent_type"}, None, InvalidToggleType),
     ]
 )

--- a/tests/strategies/pilot_users_unit_test.py
+++ b/tests/strategies/pilot_users_unit_test.py
@@ -3,7 +3,7 @@ import typing
 import pytest
 
 from ioet_feature_flag.strategies import PilotUsers
-from ioet_feature_flag.exceptions import MissingToggleAttributes
+from ioet_feature_flag.exceptions import MissingToggleAttributes, InvalidToggleAttribute
 
 
 class TestPilotUsersStrategy:
@@ -23,14 +23,17 @@ class TestPilotUsersStrategy:
         "is_enabled, current_user, allowed_users, expected_result, expected_exception",
         [
             (True, "allowed_user", "", False, MissingToggleAttributes),
-            (True, "allowed_user", "allowed_user", True, None),
-            (True, "allowed_user", "allowed_user,another_user", True, None),
-            (False, "allowed_user", "allowed_user", False, None),
-            (False, "allowed_user", "allowed_user,another_user", False, None),
-            (True, "not_allowed_user", "allowed_user", False, None),
-            (True, "not_allowed_user", "allowed_user,another_user", False, None),
-            (False, "not_allowed_user", "allowed_user", False, None),
-            (False, "not_allowed_user", "allowed_user,another_user", False, None),
+            (True, "allowed_user", "test_user, test_another_user", False, InvalidToggleAttribute),
+            (True, "allowed_user", ["allowed_user"], True, None),
+            (True, "allowed_user", ["allowed_user", "another_user"], True, None),
+            (True, "allowed_user", [" allowed_user", "another_user"], True, None),
+            (True, "allowed_user", ["allowed_user ", "another_user"], True, None),
+            (False, "allowed_user", ["allowed_user"], False, None),
+            (False, "allowed_user", ["allowed_user", "another_user"], False, None),
+            (True, "not_allowed_user", ["allowed_user"], False, None),
+            (True, "not_allowed_user", ["allowed_user", "another_user"], False, None),
+            (False, "not_allowed_user", ["allowed_user"], False, None),
+            (False, "not_allowed_user", ["allowed_user", "another_user"], False, None),
         ],
     )
     def test__returns_toggles_specified_in_attributes(


### PR DESCRIPTION
#### 🤔 Why?

- Make it more convenient for the user to add multiple users to the `pilot_users` feature type

#### 🛠 What I changed:

- the `allowed_users` used to be an array, and each user comma separated, but to make it easier for the user and less prone to errors, it was decided to change that string by a list.

#### 🗃️ Jira Issues:

- [FF-73](https://ioetec.atlassian.net/browse/FF-73)



[FF-73]: https://ioetec.atlassian.net/browse/FF-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ