### PR TITLE
feat: FF-79 Return boolean when only one flag is provided

### DIFF
--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -14,9 +14,12 @@ class Router:
 
     def get_toggles(
         self,
-        toggle_names: typing.List[str],
+        toggle_names: typing.Union[typing.List[str], str],
         toggle_context: typing.Optional[ToggleContext] = None,
-    ) -> typing.Tuple[bool, ...]:
+    ) -> typing.Union[typing.Tuple[bool, ...], bool]:
+        if isinstance(toggle_names, str):
+            toggle_names = [toggle_names]
+
         available_toggles = self._provider.get_toggle_list()
 
         missing_toogles = [
@@ -32,14 +35,19 @@ class Router:
             for toggle_name in toggle_names
         ]
 
-        toggle_types = [
+        toggle_strategies = [
             get_toggle_strategy(toggle_attribute)
             for toggle_attribute in toggle_attributes
         ]
 
-        return tuple(
-            toggle.is_enabled(context=toggle_context) for toggle in toggle_types
+        result = tuple(
+            toggle.is_enabled(context=toggle_context) for toggle in toggle_strategies
         )
+
+        if len(result) == 1:
+            return result[0]
+
+        return result
 
     def get_all_toggles(
         self,

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -32,7 +32,7 @@ class Toggles:
                 raise exceptions.InvalidDecisionFunction(
                     (
                         "when_on and when_off parameters can't be boolean. "
-                        "We have added this restriction to avoid a lot of is statements in your app"
+                        "We have added this restriction to avoid a lot of if statements in your app"
                     )
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "ioet-feature-flag"
-version = "1.6.0"
+version = "1.7.2"
 description = "Feature Flag library for ioet internal apps"
 authors = ["ioet <info@ioet.com>"]
 readme = "README.md"

--- a/scripts/test_import/dummy_module.py
+++ b/scripts/test_import/dummy_module.py
@@ -12,6 +12,14 @@ def dummy_decision(get_toggles, when_on, when_off, context=None):
 
 
 @toggles.toggle_decision
+def dummy_decision_when_off(get_toggles, when_on, when_off, context=None):
+    is_enabled = get_toggles(["disabled-flag"], context)
+    if is_enabled:
+        return when_on
+    return when_off
+
+
+@toggles.toggle_decision
 def dummy_decision_user(get_toggles, when_on, when_off, context=None):
     is_enabled = get_toggles(["user-dummy-flag"], context)
     if is_enabled:
@@ -21,6 +29,13 @@ def dummy_decision_user(get_toggles, when_on, when_off, context=None):
 
 def get_name():
     return dummy_decision(
+        when_on="name-a",
+        when_off="name-b",
+    )
+
+
+def get_name_b():
+    return dummy_decision_when_off(
         when_on="name-a",
         when_off="name-b",
     )

--- a/scripts/test_import/dummy_test.py
+++ b/scripts/test_import/dummy_test.py
@@ -5,5 +5,9 @@ def test_get_name():
     assert dummy_module.get_name() == "name-a"
 
 
+def test_get_name_b():
+    assert dummy_module.get_name_b() == "name-b"
+
+
 def test_get_name_user():
     assert dummy_module.get_name_user() == "name-a"

--- a/scripts/test_import/feature_toggles/feature-toggles.yaml
+++ b/scripts/test_import/feature_toggles/feature-toggles.yaml
@@ -2,6 +2,9 @@ test:
     dummy-flag:
         enabled: true
         type: static
+    disabled-flag:
+        enabled: false
+        type: static
     user-dummy-flag:
         enabled: true
         type: pilot_users

--- a/tests/toggles_unit_test.py
+++ b/tests/toggles_unit_test.py
@@ -64,5 +64,5 @@ class TestTogglesDecisionMethod:
 
         assert str(error.value) == (
             "when_on and when_off parameters can't be boolean. "
-            "We have added this restriction to avoid a lot of is statements in your app"
+            "We have added this restriction to avoid a lot of if statements in your app"
         )

--- a/usage_examples/functional_usage.md
+++ b/usage_examples/functional_usage.md
@@ -73,7 +73,13 @@ body = create_email_body("Gustavo", "2342937")
 print(body)
 ```
 
-> **Please note:** The function `get_toggles` used on the decision function always expects a list and **returns a tuple**. So, if you need to get a single flag, you have to send it inside a list and **unpack** the returned value.
+> **IMPORTANT NOTE:** The function `get_toggles` used on the decision function expects a list and **will return a tuple** if you pass mulltiple flags to it and **you will need to unpack it**. However, if you pass only one flag (as in, a list with just one element), **it will return a boolean** with the value of the flag that you specified. We made this decision to avoid confusion when using the result in an if statement.
+
+```python
+my_toggle_a, my_toggle_b = get_toggles(["myToggleA", "myToggleB"])  # returns a tuple
+my_toggle = get_toggles(["myToggleA"])  # returns a boolean
+my_toggle = get_toggles("myToggleA")  # also returns a boolean
+```
 
 ## Toggling decision without context
 

--- a/usage_examples/object_oriented_usage.md
+++ b/usage_examples/object_oriented_usage.md
@@ -85,7 +85,13 @@ class CreateEmailBodyCase2:
         """
 
 ```
-> **Please note:** The function `get_toggles` used on the decision function always expects a list and **returns a tuple**. So, if you need to get a single flag, you have to send it inside a list and **unpack** the returned value.
+> **IMPORTANT NOTE:** The function `get_toggles` used on the decision function expects a list and **will return a tuple** if you pass mulltiple flags to it and **you will need to unpack it**. However, if you pass only one flag (as in, a list with just one element), **it will return a boolean** with the value of the flag that you specified. We made this decision to avoid confusion when using the result in an if statement.
+
+```python
+my_toggle_a, my_toggle_b = get_toggles(["myToggleA", "myToggleB"])  # returns a tuple
+my_toggle = get_toggles(["myToggleA"])  # returns a boolean
+my_toggle = get_toggles("myToggleA")  # also returns a boolean
+```
 
 Then, the dependency factory for the use case is updated:
 ```python


### PR DESCRIPTION
#### 🤔 Why?

- Return a boolean when only one flag name is provided to avoid confusion when using it in an `if` statement.

#### 🛠 What I changed:

- Modified the toggle router to:
1. allow the user to pass a string if they only want one flag
2. return a boolean if only one flag name is provided
- Updated tests respectively

#### 🗃️ Jira Issues:

- [FF-79](https://ioetec.atlassian.net/browse/FF-79)



[FF-79]: https://ioetec.atlassian.net/browse/FF-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ