### PR TITLE
fix: FF-80 Added new exception when context is not provided

### DIFF
--- a/ioet_feature_flag/exceptions.py
+++ b/ioet_feature_flag/exceptions.py
@@ -34,3 +34,10 @@ class InvalidToggleAttribute(Exception):
     Exception raised when a specific toggle attribute not valid.
     For example, when the toggle attribute "date" is not a valid date.
     """
+
+
+class MissingToggleContext(Exception):
+    """
+    Exception raised when a toggle type needs a toggle context, but it was not provided.
+    For example, when the toggle type "pilot_users" is called without a context to know the user.
+    """

--- a/ioet_feature_flag/strategies/pilot_users.py
+++ b/ioet_feature_flag/strategies/pilot_users.py
@@ -1,7 +1,11 @@
 import typing
 
 from .strategy import Strategy
-from ..exceptions import MissingToggleAttributes, InvalidToggleAttribute
+from ..exceptions import (
+    MissingToggleAttributes,
+    InvalidToggleAttribute,
+    MissingToggleContext,
+)
 from ..toggle_context import ToggleContext
 
 
@@ -24,5 +28,9 @@ class PilotUsers(Strategy):
             allowed_users=[user.strip() for user in allowed_users],
         )
 
-    def is_enabled(self, context: ToggleContext) -> bool:
+    def is_enabled(self, context: typing.Optional[ToggleContext] = None) -> bool:
+        if not context:
+            raise MissingToggleContext(
+                "Toggle context is required to compute toggle's state"
+            )
         return self._enabled and context.username in self._allowed_users

--- a/ioet_feature_flag/strategies/role_based.py
+++ b/ioet_feature_flag/strategies/role_based.py
@@ -1,7 +1,11 @@
 import typing
 
 from .strategy import Strategy
-from ..exceptions import MissingToggleAttributes, InvalidToggleAttribute
+from ..exceptions import (
+    MissingToggleAttributes,
+    InvalidToggleAttribute,
+    MissingToggleContext,
+)
 from ..toggle_context import ToggleContext
 
 
@@ -25,6 +29,8 @@ class RoleBased(Strategy):
         )
 
     def is_enabled(self, context: typing.Optional[ToggleContext] = None) -> bool:
-        if context:
-            return self._enabled and context.role in self._allowed_roles
-        return False
+        if not context:
+            raise MissingToggleContext(
+                "Toggle context is required to compute toggle's state"
+            )
+        return self._enabled and context.role in self._allowed_roles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "ioet-feature-flag"
-version = "1.7.2"
+version = "1.7.3"
 description = "Feature Flag library for ioet internal apps"
 authors = ["ioet <info@ioet.com>"]
 readme = "README.md"

--- a/tests/strategies/role_based_unit_test.py
+++ b/tests/strategies/role_based_unit_test.py
@@ -3,10 +3,14 @@ import typing
 import pytest
 
 from ioet_feature_flag.strategies import RoleBased
-from ioet_feature_flag.exceptions import MissingToggleAttributes, InvalidToggleAttribute
+from ioet_feature_flag.exceptions import (
+    MissingToggleAttributes,
+    InvalidToggleAttribute,
+    MissingToggleContext,
+)
 
 
-class TestPilotUsersStrategy:
+class TestRoleBasedStrategy:
     @pytest.fixture
     def dependency_factory(self, mocker):
         def _factory(**context_attributes: typing.Dict):
@@ -41,36 +45,42 @@ class TestPilotUsersStrategy:
         attributes = {
             "enabled": is_enabled,
             "type": "role_based",
-            "roles": allowed_roles
+            "roles": allowed_roles,
         }
         toggle_context = dependency_factory(role=current_role)["toggle_context"]
 
         role_based_strategy = RoleBased.from_attributes(attributes)
-        assert (
-            role_based_strategy.is_enabled(context=toggle_context)
-            == expected_result
-        )
+        assert role_based_strategy.is_enabled(context=toggle_context) == expected_result
 
     @pytest.mark.parametrize(
-        "is_enabled, current_role, allowed_roles, expected_exception",
+        "is_enabled, allowed_roles, expected_exception",
         [
-            (True, "allowed_user", "", MissingToggleAttributes),
-            (True, "allowed_user", "test_user, test_another_user", InvalidToggleAttribute),
-        ]
+            (True, "", MissingToggleAttributes),
+            (True, "test_user, test_another_user", InvalidToggleAttribute),
+        ],
     )
     def test__raises_an_error__when_attributes_are_not_formatted_correctly(
-        self,
-        is_enabled: bool,
-        current_role: str,
-        allowed_roles: str,
-        dependency_factory: typing.Callable,
-        expected_exception: typing.Any
+        self, is_enabled: bool, allowed_roles: str, expected_exception: typing.Any
     ):
         attributes = {
             "enabled": is_enabled,
             "type": "role_based",
-            "roles": allowed_roles
+            "roles": allowed_roles,
         }
 
         with pytest.raises(expected_exception):
             RoleBased.from_attributes(attributes)
+
+    def test__raises_an_exception__when_toggle_context_was_not_provided(
+        self,
+    ):
+        expected_error_message = "Toggle context is required to compute toggle's state"
+        attributes = {
+            "enabled": True,
+            "type": "role_based",
+            "roles": ["allRoles"],
+        }
+        role_based_strategy = RoleBased.from_attributes(attributes)
+
+        with pytest.raises(MissingToggleContext, match=expected_error_message):
+            role_based_strategy.is_enabled()


### PR DESCRIPTION
#### 🤔 Why?

- Because there are some feature toggles that need a context to be able to compute the toggle value properly.

#### 🛠 What I changed:

- Created a new exception to be used when the toggle context is missing
- Added new unit tests on pilot users and role based FF to check the new exception is raised
- Fixed pilot users signature
- Fixed typos and removed unused parameters on tests

#### 🗃️ Jira Issues:

- [FF-80](https://ioetec.atlassian.net/browse/FF-80)

#### 🚦 Functional Testing Results:

![image](https://github.com/ioet/ioet-feature-flag/assets/67567150/74acaeb9-4db2-4e70-8742-a181a599a21e)


[FF-80]: https://ioetec.atlassian.net/browse/FF-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ