### PR TITLE
fix: FF-78 made root folder selection consistent

### DIFF
--- a/ioet_feature_flag/providers/json_toggle_provider.py
+++ b/ioet_feature_flag/providers/json_toggle_provider.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import json
 import typing
 import os
@@ -8,7 +9,7 @@ from .provider import Provider
 
 class JsonToggleProvider(Provider):
     def __init__(self, toggles_file_path: str) -> None:
-        self._path = toggles_file_path
+        self._path: Path = Path(toggles_file_path).resolve()
         self._environment = os.getenv("ENVIRONMENT")
         self._validate_environment()
 

--- a/ioet_feature_flag/providers/yaml_toggle_provider.py
+++ b/ioet_feature_flag/providers/yaml_toggle_provider.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import yaml
 import typing
 import os
@@ -8,7 +9,7 @@ from .provider import Provider
 
 class YamlToggleProvider(Provider):
     def __init__(self, toggles_file_path: str) -> None:
-        self._path = toggles_file_path
+        self._path: Path = Path(toggles_file_path).resolve()
         self._environment = os.getenv("ENVIRONMENT")
         self._validate_environment()
 

--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 import typing
 
 from .providers import Provider, YamlToggleProvider
@@ -5,12 +7,17 @@ from .exceptions import ToggleNotFoundError
 from .strategies import get_toggle_strategy
 from .toggle_context import ToggleContext
 
-_TOGGLES_LOCATION = "./feature_toggles/feature-toggles.yaml"
+_TOGGLES_LOCATION: typing.List[str] = ["feature_toggles", "feature-toggles.yaml"]
 
 
 class Router:
-    def __init__(self, provider: typing.Optional[Provider] = None):
-        self._provider = provider or YamlToggleProvider(_TOGGLES_LOCATION)
+    def __init__(
+        self,
+        root_dir: Path,
+        provider: typing.Optional[Provider] = None,
+    ):
+        toggles_location = os.path.join(root_dir, *_TOGGLES_LOCATION)
+        self._provider = provider or YamlToggleProvider(toggles_location)
 
     def get_toggles(
         self,

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from functools import wraps
 
 import typing
@@ -9,8 +10,10 @@ from .toggle_context import ToggleContext
 
 
 class Toggles:
-    def __init__(self, provider: typing.Optional[Provider] = None) -> None:
-        self._router = Router(provider)
+    def __init__(
+        self, project_root: Path, provider: typing.Optional[Provider] = None
+    ) -> None:
+        self._router = Router(root_dir=project_root, provider=provider)
 
     def toggle_decision(self, decision_function: types.TOOGLE_DECISION):
         @wraps(decision_function)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "ioet-feature-flag"
-version = "1.7.3"
+version = "1.7.4"
 description = "Feature Flag library for ioet internal apps"
 authors = ["ioet <info@ioet.com>"]
 readme = "README.md"

--- a/scripts/test_import/dummy_module.py
+++ b/scripts/test_import/dummy_module.py
@@ -1,6 +1,7 @@
+from pathlib import Path
 import ioet_feature_flag
 
-toggles = ioet_feature_flag.Toggles()
+toggles = ioet_feature_flag.Toggles(project_root=Path(__file__).parent)
 
 
 @toggles.toggle_decision

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from faker import Faker
+
+import pytest
+
+
+@pytest.fixture
+def faker() -> Faker:
+    return Faker()

--- a/tests/router_unit_test.py
+++ b/tests/router_unit_test.py
@@ -1,6 +1,9 @@
-import pytest
+from pathlib import Path
 import typing
 from freezegun import freeze_time
+
+import pytest
+from faker import Faker
 
 from ioet_feature_flag.exceptions import ToggleNotFoundError
 from ioet_feature_flag.router import Router
@@ -9,7 +12,7 @@ from ioet_feature_flag.toggle_context import ToggleContext
 
 class TestGetTogglesMethod:
     @pytest.fixture(name="dependency_factory")
-    def __dependency_factory(self, mocker) -> typing.Callable:
+    def __dependency_factory(self, mocker, faker: Faker) -> typing.Callable:
         def _factory(toggle_values: typing.Dict):
             def _mocked_get_toggle_attributes(toggle_name):
                 return toggle_values[toggle_name]
@@ -21,7 +24,8 @@ class TestGetTogglesMethod:
                     get_toggle_attributes=mocker.Mock(
                         side_effect=_mocked_get_toggle_attributes,
                     ),
-                )
+                ),
+                "root_dir": Path(faker.file_path()),
             }
 
         return _factory
@@ -94,17 +98,17 @@ class TestGetTogglesMethod:
             "another_pilot_users_toggle": {
                 "enabled": True,
                 "type": "pilot_users",
-                "allowed_users": ["another_user"]
+                "allowed_users": ["another_user"],
             },
             "cutover_strategy": {
                 "enabled": True,
                 "type": "cutover",
-                "date": "2023-08-20 10:00"
+                "date": "2023-08-20 10:00",
             },
             "another_cutover_strategy": {
                 "enabled": True,
                 "type": "cutover",
-                "date": "2023-08-20 16:00"
+                "date": "2023-08-20 16:00",
             },
         }
         dependencies = dependency_factory(toggle_values=toggles)
@@ -134,9 +138,7 @@ class TestGetTogglesMethod:
 
         dependencies = dependency_factory(toggle_values=toggles)
         toggle_router = Router(**dependencies)
-        another_toggle = toggle_router.get_toggles(
-            ["another_toggle"]
-        )
+        another_toggle = toggle_router.get_toggles(["another_toggle"])
 
         assert isinstance(another_toggle, bool)
         assert not another_toggle
@@ -152,9 +154,7 @@ class TestGetTogglesMethod:
 
         dependencies = dependency_factory(toggle_values=toggles)
         toggle_router = Router(**dependencies)
-        some_toggle = toggle_router.get_toggles(
-            "some_toggle"
-        )
+        some_toggle = toggle_router.get_toggles("some_toggle")
 
         assert isinstance(some_toggle, bool)
         assert some_toggle

--- a/tests/toggles_unit_test.py
+++ b/tests/toggles_unit_test.py
@@ -20,7 +20,7 @@ class TestTogglesDecisionMethod:
             return_value=router,
         )
         decision_function = mocker.Mock(return_value=when_on)
-        toggles = Toggles(provider=provider)
+        toggles = Toggles(provider=provider, project_root=mocker.Mock())
         toggle_context = mocker.Mock() if uses_context else None
 
         decision = toggles.toggle_decision(decision_function)
@@ -35,10 +35,15 @@ class TestTogglesDecisionMethod:
 
     def test__raises_an_error_when_toggle_values_are_from_different_types(self, mocker):
         provider = mocker.Mock()
+        router = mocker.Mock()
+        mocker.patch(
+            "ioet_feature_flag.toggles.Router",
+            return_value=router,
+        )
         when_on = 1
         when_off = "string"
         decision_function = mocker.Mock(return_value=when_on)
-        toggles = Toggles(provider=provider)
+        toggles = Toggles(provider=provider, project_root=mocker.Mock())
 
         with pytest.raises(InvalidDecisionFunction) as error:
             toggles.toggle_decision(decision_function)(
@@ -52,10 +57,15 @@ class TestTogglesDecisionMethod:
 
     def test__raises_an_error_when_toggle_values_are_boolean(self, mocker):
         provider = mocker.Mock()
+        router = mocker.Mock()
+        mocker.patch(
+            "ioet_feature_flag.toggles.Router",
+            return_value=router,
+        )
         when_on = True
         when_off = False
         decision_function = mocker.Mock(return_value=when_on)
-        toggles = Toggles(provider=provider)
+        toggles = Toggles(provider=provider, project_root=mocker.Mock())
 
         with pytest.raises(InvalidDecisionFunction) as error:
             toggles.toggle_decision(decision_function)(

--- a/usage_examples/functional_usage.md
+++ b/usage_examples/functional_usage.md
@@ -17,16 +17,24 @@ dev:
 
 > **Note:** Both flags need to be declared as false in any other environment that isn't meant to have the feature yet. If an environment does not have a flag declared, the library will raise an exception.
 
+> **Info:**
+> By default, the library will search for a YAML file on `./feature_toggles/feature-toggles.yaml`.
+> To override this behavior, create a `Toggles` instance specifying the `provider` parameter.
+> This way, you can not only change the toggles path but also use any other provider described on
+> README file.
+
 ## Using the library
 The feature flag library includes a decorator to mark functions as toggle routers and use them in other functions:
 
 ```python
 import ioet_feature_flag
 
+from pathlib import Path
 import typing
 
-
-toggles = ioet_feature_flag.Toggles()
+# Here, since the project root is the containing folder of the file,
+# the feature toggles folder must be at the same level of this file
+toggles = ioet_feature_flag.Toggles(project_root=Path(__file__).parent)
 
 
 @toggles.toggle_decision
@@ -81,16 +89,24 @@ my_toggle = get_toggles(["myToggleA"])  # returns a boolean
 my_toggle = get_toggles("myToggleA")  # also returns a boolean
 ```
 
+> **Important:**
+> Please note that the Toggles class needs a `project_root: Path` parameter. This is done to make the default path 
+> of the toggles file consistent. If another path or provider needs to be used, you can do it, the project root parameter
+> will not be considered.
+
 ## Toggling decision without context
 
 You can also toggle between function calls without sending context, like this:
 ```python
 import ioet_feature_flag
 
+from pathlib import Path
 import typing
 
 
-toggles = ioet_feature_flag.Toggles()
+# Here, since the project root is the containing folder of the file,
+# the feature toggles folder must be at the same level of this file
+toggles = ioet_feature_flag.Toggles(project_root=Path(__file__).parent)
 
 
 def gen_one_pokedex():

--- a/usage_examples/object_oriented_usage.md
+++ b/usage_examples/object_oriented_usage.md
@@ -16,6 +16,11 @@ Suppose we have an email body builder in our application. A new feature to inclu
 └── main.py
 
 ```
+> **Info:**
+> By default, the library will search for a YAML file on `./feature_toggles/feature-toggles.yaml`.
+> To override this behavior, create a `Toggles` instance specifying the `provider` parameter.
+> This way, you can not only change the toggles path but also use any other provider described on
+> README file.
 
 ## Adding feature flags
 Since it's needed to test the new feature locally, a new pair of toggles are added to the development environment in the `feature-toggles.yaml` file:
@@ -93,15 +98,33 @@ my_toggle = get_toggles(["myToggleA"])  # returns a boolean
 my_toggle = get_toggles("myToggleA")  # also returns a boolean
 ```
 
-Then, the dependency factory for the use case is updated:
+Now, the dependency factory for the use case needs to be updated to include the toggles class.
+
+> **Important:** 
+> Please note that the Toggles class needs a `project_root: Path` parameter. This is done to make the default path
+> of the toggles file consistent. If another path or provider needs to be used, you can do it, the project root parameter
+> will not be considered.
+
+For this example, project root path was declared on `dependency_factories/__init__.py`:
+```python
+from pathlib import Path
+
+
+PROJECT_ROOT: Path = Path(__file__).parent.parent
+
+```
+In the use case's dependency factory, we just add the toggles dependency liek this: 
+
 ```python
 from ioet_feature_flag import Toggles
 
 import cases
 
+from . import PROJECT_ROOT
+
 
 def get_create_email_body_case() -> cases.CreateEmailBodyCase2:
-    return cases.CreateEmailBodyCase2(feature_toggles=Toggles())
+    return cases.CreateEmailBodyCase2(feature_toggles=Toggles(project_root=PROJECT_ROOT))
 
 ```
 


### PR DESCRIPTION
#### 🤔 Why?

- Because the feature toggles are discovered correctly when called from the project root folder, but when called from a project's sub directory they are not found

#### 🛠 What I changed:

- Added a new argument to the Toggles contructor to use a path as the project root folder
- Updated the router class to build the toggles location path based on the root directory recieved
- Updated the YAML and JSON providers to resolve the toggles path before reading the file
- Modified the examples to include the usage of the project root  parameter
- Added callouts to show that the param will only work when no provider is specified

#### 🗃️ Jira Issues:

- [FF-78](https://ioetec.atlassian.net/browse/FF-78)

#### 🚦 Functional Testing Results:
##### Before:
[Screencast from 2023-11-26 15-36-22.webm](https://github.com/ioet/ioet-feature-flag/assets/67567150/8c2de9b7-ad4b-4592-aff4-b381fc3b2108)


##### After:
[Screencast from 2023-11-26 15-32-23.webm](https://github.com/ioet/ioet-feature-flag/assets/67567150/c1fb4d90-d773-4c83-8f26-00e86601912a)


[FF-78]: https://ioetec.atlassian.net/browse/FF-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ