### PR TITLE
docs: FF-86 Add docstrings to external classes and methods

### DIFF
--- a/ioet_feature_flag/providers/aws_appconfig_toggle_provider.py
+++ b/ioet_feature_flag/providers/aws_appconfig_toggle_provider.py
@@ -6,6 +6,24 @@ from .provider import Provider
 
 
 class AWSAppConfigToggleProvider(Provider):
+    """
+    Provider for AWS AppConfig.
+
+    The instructions to set up AWS AppConfig
+    here: https://github.com/ioet/ioet-feature-flag/tree/main#aws-appconfig
+
+    The following env variables must be set in order for this provider
+    to work:
+
+    AWS_APPCONFIG_APP=your-appconfig-app-name
+    AWS_APPCONFIG_ENV=your-appconfig-environment
+    AWS_APPCONFIG_PROFILE=your-appconfig-profile
+    AWS_DEFAULT_REGION=us-east-2
+    AWS_ACCESS_KEY_ID="your-access-key-id"
+    AWS_SECRET_ACCESS_KEY="your-access-key"
+    AWS_SESSION_TOKEN="your-session-token"
+    """
+
     def __init__(self) -> None:
         self._appconfig = AppConfigHelper(
             os.environ["AWS_APPCONFIG_APP"],

--- a/ioet_feature_flag/providers/json_toggle_provider.py
+++ b/ioet_feature_flag/providers/json_toggle_provider.py
@@ -8,6 +8,24 @@ from .provider import Provider
 
 
 class JsonToggleProvider(Provider):
+    """
+    Provider for .json feature toggle files.
+
+    This provider expects the file to have the following format
+
+    {
+        "yourEnvironment": {
+            "yourToggleName": {
+                "enabled": true,
+                "type": "static"
+            }
+        }
+    }
+
+    You must set the `ENVIRONMENT` env variable and it must match
+    `"yourEnvironment"`, otherwise it will throw an exception.
+    """
+
     def __init__(self, toggles_file_path: str) -> None:
         self._path: Path = Path(toggles_file_path).resolve()
         self._environment = os.getenv("ENVIRONMENT")

--- a/ioet_feature_flag/providers/yaml_toggle_provider.py
+++ b/ioet_feature_flag/providers/yaml_toggle_provider.py
@@ -8,6 +8,20 @@ from .provider import Provider
 
 
 class YamlToggleProvider(Provider):
+    """
+    Provider for .yaml feature toggle files.
+
+    This provider expects the file to have the following format
+
+    your_environment:
+        your_toggle_name:
+            enabled: true
+            type: static
+
+    You must set the `ENVIRONMENT` env variable and it must match
+    `your_environment"`, otherwise it will throw an exception.
+    """
+
     def __init__(self, toggles_file_path: str) -> None:
         self._path: Path = Path(toggles_file_path).resolve()
         self._environment = os.getenv("ENVIRONMENT")

--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -59,7 +59,7 @@ class Router:
     def get_all_toggles(
         self,
         context: typing.Optional[ToggleContext] = None,
-    ):
+    ) -> typing.Dict[str, bool]:
         available_toggles = self._provider.get_toggle_list()
 
         raw_toggles = {

--- a/ioet_feature_flag/toggle_context.py
+++ b/ioet_feature_flag/toggle_context.py
@@ -2,6 +2,13 @@ import typing
 
 
 class ToggleContext:
+    """
+    Class used to provide context to the toggle router.
+
+    This class is necessary when you have feature toggles that depend
+    on user information, such as username or role.
+    """
+
     def __init__(
         self, username: str, role: str, **attributes: typing.Dict[str, typing.Any]
     ) -> None:

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -16,6 +16,13 @@ class Toggles:
         self._router = Router(root_dir=project_root, provider=provider)
 
     def toggle_decision(self, decision_function: types.TOOGLE_DECISION):
+        """
+        Decorator function for your toggle point.
+
+        :raises InvalidDecisionFunction: This exception is thrown when either
+            `when_on` and `when_off` are different types, or when any of them are booleans
+        """
+
         @wraps(decision_function)
         def _wraps(
             when_on: types.TOGGLED_VALUE,
@@ -48,5 +55,24 @@ class Toggles:
     def get_all_toggles(
         self,
         context: typing.Optional[ToggleContext] = None,
-    ):
+    ) -> typing.Dict[str, bool]:
+        """
+        Returns a list of all the toggles in the following format:
+
+        ```
+        {
+            "my_toggle": True,
+            "my_other_toggle": False,
+        }
+        ```
+
+        Considerations:
+        1. It only gets the toggles for the current environment,
+           the one defined by the `ENVIRONMENT` env variable.
+        2. Although the `context` parameter is optional, most of the
+           times you will actually need to provide it, otherwise
+           this function will throw an exception if you have the
+           `pilot_users` or `role_based` feature types.
+        """
+
         return self._router.get_all_toggles(context)


### PR DESCRIPTION
#### 🤔 Why?

- Make it more convenient for developers to access docstring documentation with their IDEs

#### 🛠 What I changed:

- Added docstrings to functions and classes that are meant to be used externally

#### 🗃️ Jira Issues:

- [FF-86](https://ioetec.atlassian.net/browse/FF-86)



[FF-86]: https://ioetec.atlassian.net/browse/FF-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ