### PR TITLE
feat: FF-87 Refactor providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # ioet Feature Flags
 
 Feature Flags library to standardize feature toggles across our Internal Apps.
-The current implementation is pretty bare-bones and only checks whether the flag is enabled or not.
-However, we aim to follow [this standard](https://martinfowler.com/articles/feature-toggles.html) as our framework.
+We are aim to follow [this standard](https://martinfowler.com/articles/feature-toggles.html) as our framework.
 
-Moreover, we are planning to support [AWS AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html) as the main feature flag provider. However, we may support other providers in the future.
+The default provider that we support is a Yaml or Json file hosted in the project's repo.
+However, we also support other providers such as [AWS AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html). We may support other providers in the future.
+
+The supported providers are listed in the [Providers](#providers) section.
 
 
 ## Installation
@@ -30,7 +32,7 @@ poetry add git+ssh://git@github.com/ioet/ioet-feature-flag.git#<branch-or-tag>
 
 ## Requirements
 
-By default, the library attempts to read a file located at `./feature_toggles/feature-toggles.yaml`, so make sure to create a file in that location with the following format:
+Create a yaml file. It can be located anywhere you want, for example, at `./feature_toggles/feature-toggles.yaml`. Make sure that it has the following format:
 ```
 production:
   some_toggle:
@@ -42,7 +44,7 @@ staging:
 ```
 The flags are going to be taken from either the `production` or `staging` section depending on the `ENVIRONMENT` env variable.
 
-It is also possible to specify a different file location, or use other formats or providers, such as JSON or AWS AppConfig. This is documented under the "Providers" section.
+It is also possible to specify a different file location, or use other formats or providers, such as JSON or AWS AppConfig. This is documented in the [Providers](#providers) section.
 
 
 ## Backend Usage

--- a/ioet_feature_flag/router.py
+++ b/ioet_feature_flag/router.py
@@ -1,23 +1,17 @@
-import os
-from pathlib import Path
 import typing
 
-from .providers import Provider, YamlToggleProvider
+from .providers import Provider
 from .exceptions import ToggleNotFoundError
 from .strategies import get_toggle_strategy
 from .toggle_context import ToggleContext
-
-_TOGGLES_LOCATION: typing.List[str] = ["feature_toggles", "feature-toggles.yaml"]
 
 
 class Router:
     def __init__(
         self,
-        root_dir: Path,
-        provider: typing.Optional[Provider] = None,
+        provider: Provider,
     ):
-        toggles_location = os.path.join(root_dir, *_TOGGLES_LOCATION)
-        self._provider = provider or YamlToggleProvider(toggles_location)
+        self._provider = provider
 
     def get_toggles(
         self,

--- a/ioet_feature_flag/toggles.py
+++ b/ioet_feature_flag/toggles.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from functools import wraps
 
 import typing
@@ -11,10 +10,8 @@ from .helpers import validators
 
 
 class Toggles:
-    def __init__(
-        self, project_root: Path, provider: typing.Optional[Provider] = None
-    ) -> None:
-        self._router = Router(root_dir=project_root, provider=provider)
+    def __init__(self, provider: Provider) -> None:
+        self._router = Router(provider=provider)
 
     def toggle_decision(self, decision_function: types.TOOGLE_DECISION):
         """

--- a/scripts/test_import/dummy_module.py
+++ b/scripts/test_import/dummy_module.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 import ioet_feature_flag
 
-toggles = ioet_feature_flag.Toggles(project_root=Path(__file__).parent)
+provider = ioet_feature_flag.YamlToggleProvider('./feature_toggles/feature-toggles.yaml')
+toggles = ioet_feature_flag.Toggles(provider)
 
 
 @toggles.toggle_decision

--- a/tests/router_unit_test.py
+++ b/tests/router_unit_test.py
@@ -1,9 +1,7 @@
-from pathlib import Path
 import typing
 from freezegun import freeze_time
 
 import pytest
-from faker import Faker
 
 from ioet_feature_flag.exceptions import ToggleNotFoundError
 from ioet_feature_flag.router import Router
@@ -12,7 +10,7 @@ from ioet_feature_flag.toggle_context import ToggleContext
 
 class TestGetTogglesMethod:
     @pytest.fixture(name="dependency_factory")
-    def __dependency_factory(self, mocker, faker: Faker) -> typing.Callable:
+    def __dependency_factory(self, mocker) -> typing.Callable:
         def _factory(toggle_values: typing.Dict):
             def _mocked_get_toggle_attributes(toggle_name):
                 return toggle_values[toggle_name]
@@ -25,7 +23,6 @@ class TestGetTogglesMethod:
                         side_effect=_mocked_get_toggle_attributes,
                     ),
                 ),
-                "root_dir": Path(faker.file_path()),
             }
 
         return _factory

--- a/tests/toggles_unit_test.py
+++ b/tests/toggles_unit_test.py
@@ -20,7 +20,7 @@ class TestTogglesDecisionMethod:
             return_value=router,
         )
         decision_function = mocker.Mock(return_value=when_on)
-        toggles = Toggles(provider=provider, project_root=mocker.Mock())
+        toggles = Toggles(provider=provider)
         toggle_context = mocker.Mock() if uses_context else None
 
         decision = toggles.toggle_decision(decision_function)
@@ -43,7 +43,7 @@ class TestTogglesDecisionMethod:
         when_on = 1
         when_off = "string"
         decision_function = mocker.Mock(return_value=when_on)
-        toggles = Toggles(provider=provider, project_root=mocker.Mock())
+        toggles = Toggles(provider=provider)
 
         with pytest.raises(InvalidDecisionFunction) as error:
             toggles.toggle_decision(decision_function)(
@@ -65,7 +65,7 @@ class TestTogglesDecisionMethod:
         when_on = True
         when_off = False
         decision_function = mocker.Mock(return_value=when_on)
-        toggles = Toggles(provider=provider, project_root=mocker.Mock())
+        toggles = Toggles(provider=provider)
 
         with pytest.raises(InvalidDecisionFunction) as error:
             toggles.toggle_decision(decision_function)(
@@ -94,7 +94,7 @@ class TestTogglesDecisionMethod:
         when_on = _dummy_when_on
         when_off = _dummy_when_off
         decision_function = mocker.Mock(return_value=when_on)
-        toggles = Toggles(provider=provider, project_root=mocker.Mock())
+        toggles = Toggles(provider=provider)
 
         with pytest.raises(InvalidDecisionFunction) as error:
             toggles.toggle_decision(decision_function)(

--- a/usage_examples/frontend_usage.md
+++ b/usage_examples/frontend_usage.md
@@ -15,23 +15,28 @@ Second, in your backend application, you have to define an endpoint. It can have
 }
 ```
 
-The `Toggles` class has a method `get_all_toggles` made for this purpose, so your endpoint will sort of look like this:
+The `Toggles` class has a `get_all_toggles` method made for this purpose, so your endpoint will sort of look like this:
 
 ```python
 import ioet_feature_flag
 
-toggles = ioet_feature_flag.Toggles()
+provider = ioet_feature_flag.YamlToggleProvider('./feature_toggles/feature-toggles.yaml')
+toggles = ioet_feature_flag.Toggles(provider)
 
 @router.get("/feature-flags")
 async def get_feature_flags():
-	return JSONResponse(
-		status_code=200,
-		content=toggles.get_all_toggles(context=context)
-	)
+    return JSONResponse(
+        status_code=200,
+        content=toggles.get_all_toggles(context=context)
+    )
 ```
 
-You don't need to re-initialize `ioet_feature_flag.Toggles()` for this, you can define your `toggles` object anywhere and then import it. This is just to illustrate the example.
+If you wish, you can also have a different source of feature flags for the frontend:
 
+```python
+provider = ioet_feature_flag.YamlToggleProvider('./feature_toggles/frontend-feature-toggles.yaml')
+toggles = ioet_feature_flag.Toggles(provider)
+```
 
 ## Usage
 

--- a/usage_examples/functional_usage.md
+++ b/usage_examples/functional_usage.md
@@ -3,7 +3,9 @@
 Example made by @eguezgustavo 
 
 ## Adding feature flags
-Since it's needed to test the new feature locally, a new pair of toggles are added to the development environment in the `feature-toggles.yaml` file:
+Since it's needed to test the new feature locally, a new pair of toggles are added to the development environment.
+
+Here's an example for a Yaml file:
 
 ```yaml
 dev:
@@ -15,13 +17,8 @@ dev:
     enabled: true
 ```
 
-> **Note:** Both flags need to be declared as false in any other environment that isn't meant to have the feature yet. If an environment does not have a flag declared, the library will raise an exception.
+> **Note:** Both flags need to be declared as false in any other environment that isn't meant to have the feature yet. If an environment does not have a flag declared, **the library will raise an exception**.
 
-> **Info:**
-> By default, the library will search for a YAML file on `./feature_toggles/feature-toggles.yaml`.
-> To override this behavior, create a `Toggles` instance specifying the `provider` parameter.
-> This way, you can not only change the toggles path but also use any other provider described on
-> README file.
 
 ## Using the library
 The feature flag library includes a decorator to mark functions as toggle routers and use them in other functions:
@@ -29,12 +26,10 @@ The feature flag library includes a decorator to mark functions as toggle router
 ```python
 import ioet_feature_flag
 
-from pathlib import Path
 import typing
 
-# Here, since the project root is the containing folder of the file,
-# the feature toggles folder must be at the same level of this file
-toggles = ioet_feature_flag.Toggles(project_root=Path(__file__).parent)
+provider = ioet_feature_flag.YamlToggleProvider('./feature_toggles/feature-toggles.yaml')
+toggles = ioet_feature_flag.Toggles(provider)
 
 
 @toggles.toggle_decision
@@ -89,24 +84,45 @@ my_toggle = get_toggles(["myToggleA"])  # returns a boolean
 my_toggle = get_toggles("myToggleA")  # also returns a boolean
 ```
 
-> **Important:**
-> Please note that the Toggles class needs a `project_root: Path` parameter. This is done to make the default path 
-> of the toggles file consistent. If another path or provider needs to be used, you can do it, the project root parameter
-> will not be considered.
+## Toggling behavior
+Providing that the environment variable is set to `dev`, the email body created with first example will look like this:
+```
+    Dear Alec,
+
+    Your order number 3456 has been approved.
+    
+    To cancel your order follow this link: http://cancel/3456
+
+    Cheers,
+
+    Your company team
+```
+
+Otherwise, it will look like this:
+
+```
+    Dear Alec,
+
+    Your order number 3456 has been approved.
+    
+
+
+    Cheers,
+
+    Your company team
+
+```
+
 
 ## Toggling decision without context
 
 You can also toggle between function calls without sending context, like this:
 ```python
 import ioet_feature_flag
-
-from pathlib import Path
 import typing
 
-
-# Here, since the project root is the containing folder of the file,
-# the feature toggles folder must be at the same level of this file
-toggles = ioet_feature_flag.Toggles(project_root=Path(__file__).parent)
+provider = ioet_feature_flag.YamlToggleProvider('./feature_toggles/feature-toggles.yaml')
+toggles = ioet_feature_flag.Toggles()
 
 
 def gen_one_pokedex():
@@ -138,32 +154,3 @@ def client():
   pokemons = get_pokedex_list()
 ```
 > **Note:** Even though sending a toggle context is optional, the parameter declaration on the decision function is *required* and needs to be defaulted to `None`.
-
-## Toggling behavior
-Providing that the environment variable is set to `dev`, the email body created with first example will look like this:
-```
-    Dear Alec,
-
-    Your order number 3456 has been approved.
-    
-    To cancel your order follow this link: http://cancel/3456
-
-    Cheers,
-
-    Your company team
-```
-
-Otherwise, it will look like this:
-
-```
-    Dear Alec,
-
-    Your order number 3456 has been approved.
-    
-
-
-    Cheers,
-
-    Your company team
-
-```

--- a/usage_examples/object_oriented_usage.md
+++ b/usage_examples/object_oriented_usage.md
@@ -16,14 +16,10 @@ Suppose we have an email body builder in our application. A new feature to inclu
 └── main.py
 
 ```
-> **Info:**
-> By default, the library will search for a YAML file on `./feature_toggles/feature-toggles.yaml`.
-> To override this behavior, create a `Toggles` instance specifying the `provider` parameter.
-> This way, you can not only change the toggles path but also use any other provider described on
-> README file.
 
 ## Adding feature flags
-Since it's needed to test the new feature locally, a new pair of toggles are added to the development environment in the `feature-toggles.yaml` file:
+Since it's needed to test the new feature locally, a new pair of toggles are added to the development environment.
+Here's an example with a Yaml file:
 
 ```yaml
 dev:
@@ -100,31 +96,17 @@ my_toggle = get_toggles("myToggleA")  # also returns a boolean
 
 Now, the dependency factory for the use case needs to be updated to include the toggles class.
 
-> **Important:** 
-> Please note that the Toggles class needs a `project_root: Path` parameter. This is done to make the default path
-> of the toggles file consistent. If another path or provider needs to be used, you can do it, the project root parameter
-> will not be considered.
 
-For this example, project root path was declared on `dependency_factories/__init__.py`:
-```python
-from pathlib import Path
-
-
-PROJECT_ROOT: Path = Path(__file__).parent.parent
-
-```
-In the use case's dependency factory, we just add the toggles dependency liek this: 
+In the use case's dependency factory, we just add the toggles dependency like this:
 
 ```python
 from ioet_feature_flag import Toggles
 
 import cases
 
-from . import PROJECT_ROOT
-
-
 def get_create_email_body_case() -> cases.CreateEmailBodyCase2:
-    return cases.CreateEmailBodyCase2(feature_toggles=Toggles(project_root=PROJECT_ROOT))
+    provider = ioet_feature_flag.YamlToggleProvider('./feature_toggles/feature-toggles.yaml')
+    return cases.CreateEmailBodyCase2(feature_toggles=Toggles(provider))
 
 ```
 
@@ -219,6 +201,3 @@ Otherwise, it will look like this:
     Your company team
 
 ```
-
-
-


### PR DESCRIPTION
#### 🤔 Why?

- Given that some users may want to use a different file for the frontend feature flags, the documentation was updated accordingly explaining how to do it. We also took advantage to refactor the parameters of the providers.

#### 🛠 What I changed:

- The providers no longer receives the `project_root` parameter. Same with the `Toggles` class.
- The documentation was updated according to the previously mentioned change.

#### 🗃️ Jira Issues:

- [FF-87](https://ioetec.atlassian.net/browse/FF-87)



[FF-87]: https://ioetec.atlassian.net/browse/FF-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ