### PR TITLE
feat: FF-63 Implemented template method pattern

### DIFF
--- a/ioet_feature_flag/exceptions.py
+++ b/ioet_feature_flag/exceptions.py
@@ -41,3 +41,10 @@ class MissingToggleContext(Exception):
     Exception raised when a toggle type needs a toggle context, but it was not provided.
     For example, when the toggle type "pilot_users" is called without a context to know the user.
     """
+
+
+class InvalidToggleFileFormat(Exception):
+    """
+    Exception raised when a toggle file does not return a dict-like object.
+    For example, when the toggle file is just a list of values or a scalar
+    """

--- a/ioet_feature_flag/providers/file_provider.py
+++ b/ioet_feature_flag/providers/file_provider.py
@@ -1,0 +1,50 @@
+import abc
+from pathlib import Path
+import typing
+import os
+
+from ..exceptions import ToggleNotFoundError, ToggleEnvironmentError
+from .provider import Provider
+
+
+class FileBasedProvider(Provider, abc.ABC):
+    def __init__(self, toggles_file_path: str) -> None:
+        self._path: Path = Path(toggles_file_path).resolve()
+        self._environment = os.getenv("ENVIRONMENT")
+        self._validate_environment()
+
+    @abc.abstractmethod
+    def load_toggles_from_file(self, file_object: typing.IO) -> typing.Dict[str, typing.Dict]:
+        raise NotImplementedError
+
+    def _validate_environment(self):
+        if not self._environment:
+            raise ToggleEnvironmentError(
+                "Could not retrieve toggles: Toggle environment not specified."
+            )
+        with open(self._path, "r") as toggles_file:
+            toggles = self.load_toggles_from_file(toggles_file)
+            environment_toggles: typing.Dict = toggles.get(self._environment)
+            if not environment_toggles:
+                raise ToggleEnvironmentError(
+                    f"The environment {self._environment} was not found in the"
+                    f" provided {self._path} toggles file."
+                )
+
+    def get_toggle_list(self) -> typing.List[str]:
+        with open(self._path, "r") as toggles_file:
+            toggles = self.load_toggles_from_file(toggles_file)
+            environment_toggles: typing.Dict = toggles[self._environment]
+            return list(environment_toggles.keys())
+
+    def get_toggle_attributes(self, toggle_name: str) -> typing.Dict:
+        with open(self._path, "r") as toggles_file:
+            toggles = self.load_toggles_from_file(toggles_file)
+            environment_toggles: typing.Dict = toggles.get(self._environment, {})
+            toggle_attributes = environment_toggles.get(toggle_name)
+            if not toggle_attributes:
+                raise ToggleNotFoundError(
+                    f"The toggle {toggle_name} was not found in the"
+                    f" {self._environment} environment."
+                )
+            return toggle_attributes

--- a/ioet_feature_flag/providers/yaml_toggle_provider.py
+++ b/ioet_feature_flag/providers/yaml_toggle_provider.py
@@ -1,13 +1,12 @@
-from pathlib import Path
+from typing import Dict
 import yaml
 import typing
-import os
 
-from ..exceptions import ToggleNotFoundError, ToggleEnvironmentError
-from .provider import Provider
+from ..exceptions import InvalidToggleFileFormat
+from .file_provider import FileBasedProvider
 
 
-class YamlToggleProvider(Provider):
+class YamlToggleProvider(FileBasedProvider):
     """
     Provider for .yaml feature toggle files.
 
@@ -19,42 +18,11 @@ class YamlToggleProvider(Provider):
             type: static
 
     You must set the `ENVIRONMENT` env variable and it must match
-    `your_environment"`, otherwise it will throw an exception.
+    `"your_environment"`, otherwise it will throw an exception.
     """
 
-    def __init__(self, toggles_file_path: str) -> None:
-        self._path: Path = Path(toggles_file_path).resolve()
-        self._environment = os.getenv("ENVIRONMENT")
-        self._validate_environment()
-
-    def get_toggle_list(self) -> typing.List[str]:
-        with open(self._path, "r") as toggles_file:
-            toggles = yaml.safe_load(toggles_file)
-            environment_toggles: typing.Dict = toggles[self._environment]
-            return list(environment_toggles.keys())
-
-    def get_toggle_attributes(self, toggle_name: str) -> typing.Dict:
-        with open(self._path, "r") as toggles_file:
-            toggles = yaml.safe_load(toggles_file)
-            environment_toggles: typing.Dict = toggles.get(self._environment, {})
-            toggle_attributes = environment_toggles.get(toggle_name)
-            if not toggle_attributes:
-                raise ToggleNotFoundError(
-                    f"The toggle {toggle_name} was not found in the"
-                    f" {self._environment} environment."
-                )
-            return toggle_attributes
-
-    def _validate_environment(self):
-        if not self._environment:
-            raise ToggleEnvironmentError(
-                "Could not retrieve toggles: Toggle environment not specified."
-            )
-        with open(self._path, "r") as toggles_file:
-            toggles = yaml.safe_load(toggles_file)
-            environment_toggles: typing.Dict = toggles.get(self._environment)
-            if not environment_toggles:
-                raise ToggleEnvironmentError(
-                    f"The environment {self._environment} was not found in the"
-                    f" provided {self._path} toggles file."
-                )
+    def load_toggles_from_file(self, file_object: typing.IO) -> Dict[str, Dict]:
+        toggles = yaml.safe_load(file_object)
+        if not isinstance(toggles, typing.Dict):
+            raise InvalidToggleFileFormat("The toggle file specified has an invalid format")
+        return toggles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ build_command="python release_version_tools/setup.py sdist bdist_wheel"
 branch = "main"
 version_variable = "release_version_tools/setup.py:__version__"
 upload_to_repository = false
+
+[tool.black]
+line_length = 100

--- a/tests/providers/yaml_toggle_provider_unit_test.py
+++ b/tests/providers/yaml_toggle_provider_unit_test.py
@@ -4,7 +4,11 @@ import os
 import typing
 
 from ioet_feature_flag.providers import YamlToggleProvider, Provider
-from ioet_feature_flag.exceptions import ToggleNotFoundError, ToggleEnvironmentError
+from ioet_feature_flag.exceptions import (
+    ToggleNotFoundError,
+    ToggleEnvironmentError,
+    InvalidToggleFileFormat,
+)
 
 _TOGGLES_FILE = "/tmp/app_toggles_test.yaml"
 
@@ -44,7 +48,7 @@ class TestYamlToggleProvider:
         toggles = {
             environment_name: {
                 "some_toggle": {"enabled": True},
-                "another_toggle": {"enabled": False}
+                "another_toggle": {"enabled": False},
             }
         }
         add_toggles(toggles)
@@ -62,11 +66,7 @@ class TestYamlToggleProvider:
         monkeypatch,
     ):
         monkeypatch.setenv("ENVIRONMENT", environment_name)
-        toggles = {
-            environment_name: {
-                "some_toggle": {"enabled": True}
-            }
-        }
+        toggles = {environment_name: {"some_toggle": {"enabled": True}}}
         add_toggles(toggles)
         toggle_provider: Provider = YamlToggleProvider(_TOGGLES_FILE)
 
@@ -136,4 +136,21 @@ class TestYamlToggleProvider:
             f"The environment {environment_name} was not found "
             f"in the provided {_TOGGLES_FILE} toggles file."
         )
+        assert str(error.value) == expected_message
+
+    @pytest.mark.parametrize(
+        "invalid_format", [["toogle_a"], "toggle_a"], ids=["sequence", "scalar"]
+    )
+    def test_load_toggles_from_file_raises_error_when_file_format_invalid(
+        self, monkeypatch, invalid_format: typing.Union[typing.List, str]
+    ):
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        invalid_file_path = "/tmp/invalid_toggle_file"
+        with open(invalid_file_path, "w") as toggles_file:
+            yaml.dump(invalid_format, toggles_file)
+
+        with pytest.raises(InvalidToggleFileFormat) as error:
+            YamlToggleProvider(invalid_file_path)
+
+        expected_message = "The toggle file specified has an invalid format"
         assert str(error.value) == expected_message


### PR DESCRIPTION
#### 🤔 Why?

- Because both JSON and YAML providers had barely difference on its implementations

#### 🛠 What I changed:

- Added a new abstract class for file-based toggle providers
- Refactored yaml and json toggle providers to use the new abstract class
- Added `InvalidToggleFileFormat` exception

#### 🗃️ Jira Issues:

- [FF-63](https://ioetec.atlassian.net/browse/FF-63)



[FF-63]: https://ioetec.atlassian.net/browse/FF-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ