### PR TITLE
docs: FF-61 Updated readme considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,4 @@ This library can raise different exceptions given certain conditions:
 
 ## Considerations
 - Please note that the current implementation is subject to change.
+- After performing load tests with the file-based providers, it was found that the YAML provider is slower than the JSON provider. This provider might become a performance bottleneck when used on projects with more than 300 feature toggles (provided that the project had 5 environments defined). JSON provider does not have the same issues, so take this into consideration when choosing a file format for feature flags. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "ioet-feature-flag"
-version = "1.7.4"
+version = "1.8.1"
 description = "Feature Flag library for ioet internal apps"
 authors = ["ioet <info@ioet.com>"]
 readme = "README.md"


### PR DESCRIPTION
#### 🤔 Why?

Because the load test spike revealed that the YAML provider is slower than the JSON one

#### 🛠 What I changed:

- Updated library version in `pyproject.toml`

#### 🗃️ Jira Issues:

- [FF-61](https://ioetec.atlassian.net/browse/FF-61)

#### 🚦 Functional Testing Results:

N/A


[FF-61]: https://ioetec.atlassian.net/browse/FF-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ