### PR TITLE
docs: FF-51 add C4 diagrams

### DIFF
--- a/docs/architecture/c4_component_diagram.wsd
+++ b/docs/architecture/c4_component_diagram.wsd
@@ -1,0 +1,24 @@
+@startuml C4_Elements
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+'Dependencies
+System(talent_management_system, "Talent Management System")
+
+' ioet feature flag library
+System_Boundary(ff, "Feature Flag Library") {
+    Container(toggle_provider, "Toggle Provider", "Parses information about a toggle, such as name or its attributes")
+    Container(toggle_point, "Toggle Point", "Determines which code path should be returned based on the dependent toggles")
+    Container(toggle_router, "Toggle Router", "Gets the toggles' state, using context if provided")
+    Container(toggle_strategy, "Toggle strategy", "Computes the toggle's state based on the its attributes")
+}
+
+' Systems relations
+Rel(talent_management_system, toggle_point, "Defines code paths under one or more feature toggles")
+Rel(talent_management_system, toggle_point, "Provides toggle configuration data")
+Rel(toggle_point, toggle_router, "Uses")
+Rel(toggle_router, toggle_provider, "Uses")
+Rel(toggle_router, toggle_strategy,  "Uses")
+Rel(toggle_provider, talent_management_system, "Reads toggle configuration data from a local or remote source")
+Rel(toggle_point, talent_management_system, "Executes an encapsulated piece of code based on toggles' context and type")
+
+@enduml

--- a/docs/architecture/c4_system_context_diagram.wsd
+++ b/docs/architecture/c4_system_context_diagram.wsd
@@ -1,0 +1,22 @@
+@startuml C4_Elements
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+' Users
+Person(talentManagementUser, "Talent manager")
+
+'Dependencies
+System(talent_management_system, "Talent Management System", "REST API")
+
+' ioet feature flag library
+Container(ff, "Feature Flag Library", "Code encapsulation and context-aware switching via toggle points and routers, managed via toggle configuration data")
+
+' User relations
+Rel(talentManagementUser, talent_management_system, "Executes any of the talent management system use cases", "")
+
+' Systems relations
+    Rel(ff, talent_management_system, "Executes an encapsulated piece of code based on toggles' context and type", "")
+    Rel(talent_management_system, ff, "Defines code paths under one or more feature toggles", "system dependency")
+    Rel(ff, talent_management_system, "Reads toggle configuration data from a local or remote source", "")
+    Rel(talent_management_system, ff, "Provides context data about the user", "system dependency")
+
+@enduml


### PR DESCRIPTION
#### 🤔 Why?

- Because it was needed to have C4 diagrams of the library to document the context of the library and how it fits in the development of other applications

#### 🛠 What I changed:

- Added the C4 system context diagram
- Added the C4 component diagram

#### 🗃️ Jira Issues:

https://ioetec.atlassian.net/browse/FF-51

#### 🚦 Functional Testing Results:

N/A