### PR TITLE
feat: FF-100 Env parameter for local file provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,24 @@ toggles = ioet_feature_flag.Toggles(provider=provider)
 The file format is as it follows:
 ```
 {
-  "your_feature": {
-    "enabled": true
-  },
-  "another_feature": {
-    "enabled": false,
-    "type": "standard"
+  "development": {
+    "your_feature": {
+      "enabled": true
+    },
+    "another_feature": {
+      "enabled": false,
+      "type": "standard"
+    }
   }
 }
+```
+
+`"development"` comes from the `ENVIRONMENT` env variable. If you desire to use another env variable to specify which environment to use, you can specify the `environment` parameter, like so:
+```
+provider = ioet_feature_flag.JsonToggleProvider(
+  toggles_file_path="./your/toggles.json",
+  environment=os.getenv("OTHER_ENV_VARIABLE")
+)
 ```
 
 ### Remote Git providers

--- a/ioet_feature_flag/providers/file_provider.py
+++ b/ioet_feature_flag/providers/file_provider.py
@@ -8,9 +8,13 @@ from .provider import Provider
 
 
 class FileBasedProvider(Provider, abc.ABC):
-    def __init__(self, toggles_file_path: str) -> None:
+    def __init__(
+        self,
+        toggles_file_path: str,
+        environment: typing.Optional[str] = None,
+    ) -> None:
         self._path: Path = Path(toggles_file_path).resolve()
-        self._environment = os.getenv("ENVIRONMENT")
+        self._environment = environment or os.getenv("ENVIRONMENT")
         self._validate_environment()
 
     @abc.abstractmethod


### PR DESCRIPTION
#### 🤔 Why?

- Improve the dev experience of developers by not having to specify a different env variable for their env to be able to use the local file provider.

#### 🛠 What I changed:

- Add an optional parameter to `FileBasedProvider` to receive the current env. So for example, if their env variable is named `CURRENT_ENV`, they can pass it to the constructor of the class as `FileBasedProvider(toggles_file_path="path.json", environment=os.getenv("CURRENT_ENV"))`

#### 🗃️ Jira Issues:

- [FF-100](https://ioetec.atlassian.net/browse/FF-100)



[FF-100]: https://ioetec.atlassian.net/browse/FF-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ